### PR TITLE
Improve login flow and fix commands

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -1,4 +1,3 @@
-﻿imp// app.mjs
 import express from 'express';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';

--- a/PanelDomoticoWeb/comandos/abrir.mjs
+++ b/PanelDomoticoWeb/comandos/abrir.mjs
@@ -1,6 +1,6 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    const respuesta = await sendSerial(serial, 'abrir');
+export default async function () {
+    const respuesta = await sendSerial('abrir');
     return respuesta || 'Puerta abierta';
 }

--- a/PanelDomoticoWeb/comandos/borrar.mjs
+++ b/PanelDomoticoWeb/comandos/borrar.mjs
@@ -1,7 +1,7 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    // Aquí como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
+export default async function () {
+    // AquÃ­ como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
     const id = 5;
-    return await sendSerial(serial, `borrar ${id}`);
+    return await sendSerial(`borrar ${id}`);
 }

--- a/PanelDomoticoWeb/comandos/cerrar.mjs
+++ b/PanelDomoticoWeb/comandos/cerrar.mjs
@@ -1,6 +1,6 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    const respuesta = await sendSerial(serial, 'cerrar');
+export default async function () {
+    const respuesta = await sendSerial('cerrar');
     return respuesta || 'Puerta cerrada';
 }

--- a/PanelDomoticoWeb/comandos/distancia.mjs
+++ b/PanelDomoticoWeb/comandos/distancia.mjs
@@ -1,5 +1,5 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    return await sendSerial(serial, 'distancia');
+export default async function () {
+    return await sendSerial('distancia');
 }

--- a/PanelDomoticoWeb/comandos/enrolar.mjs
+++ b/PanelDomoticoWeb/comandos/enrolar.mjs
@@ -1,7 +1,7 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    // Aquí como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
+export default async function () {
+    // AquÃ­ como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
     const id = 5;
-    return await sendSerial(serial, `enrolar ${id}`);
+    return await sendSerial(`enrolar ${id}`);
 }

--- a/PanelDomoticoWeb/comandos/huella.mjs
+++ b/PanelDomoticoWeb/comandos/huella.mjs
@@ -1,5 +1,5 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    return await sendSerial(serial, 'huella');
+export default async function () {
+    return await sendSerial('huella');
 }

--- a/PanelDomoticoWeb/comandos/pir.mjs
+++ b/PanelDomoticoWeb/comandos/pir.mjs
@@ -1,5 +1,5 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    return await sendSerial(serial, 'pir');
+export default async function () {
+    return await sendSerial('pir');
 }

--- a/PanelDomoticoWeb/comandos/rfid.mjs
+++ b/PanelDomoticoWeb/comandos/rfid.mjs
@@ -1,5 +1,5 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    return await sendSerial(serial, 'rfid');
+export default async function () {
+    return await sendSerial('rfid');
 }

--- a/PanelDomoticoWeb/comandos/voltaje.mjs
+++ b/PanelDomoticoWeb/comandos/voltaje.mjs
@@ -1,5 +1,5 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
-export default async function (serial) {
-    return await sendSerial(serial, 'voltaje');
+export default async function () {
+    return await sendSerial('voltaje');
 }

--- a/PanelDomoticoWeb/db.js
+++ b/PanelDomoticoWeb/db.js
@@ -8,12 +8,26 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Función para abrir la conexión
+// Instancia única de la base de datos
+let dbInstance;
+
+// Función para abrir (o reutilizar) la conexión
 export async function openDb() {
-    return open({
-        filename: path.join(__dirname, 'edusec.db'),
-        driver: sqlite3.Database
-    });
+    if (!dbInstance) {
+        dbInstance = await open({
+            filename: path.join(__dirname, 'edusec.db'),
+            driver: sqlite3.Database
+        });
+    }
+    return dbInstance;
+}
+
+// Obtener la instancia ya inicializada
+export function getDb() {
+    if (!dbInstance) {
+        throw new Error('Database not initialized. Call initDb first.');
+    }
+    return dbInstance;
 }
 
 // Al inicializar la app, creamos tablas si no existen

--- a/PanelDomoticoWeb/public/index.html
+++ b/PanelDomoticoWeb/public/index.html
@@ -395,10 +395,26 @@
         }
         setInterval(clockTick, 1000);
 
-        function cmd(a) {
-            toast(`Comando ${a}`);
-            if (a === 'abrir') updateDoor('🔓 Abierta');
-            if (a === 'cerrar') updateDoor('🔒 Cerrada');
+        async function cmd(a) {
+            if (!authToken) {
+                toast('No autenticado');
+                return;
+            }
+            try {
+                const res = await fetch(`/comando/${a}`, {
+                    headers: { Authorization: `Bearer ${authToken}` }
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    toast(data.error || data.msg || 'Error al ejecutar');
+                    return;
+                }
+                toast(data.resultado || 'Ejecutado');
+                if (a === 'abrir') updateDoor('🔓 Abierta');
+                if (a === 'cerrar') updateDoor('🔒 Cerrada');
+            } catch {
+                toast('Error de conexión');
+            }
         }
         function updateDoor(s) {
             document.querySelectorAll('#doorState, #homeDoorState').forEach(el => {
@@ -421,15 +437,28 @@
 
         // Variables globales
         let currentUser = null;
+        let authToken = null;
 
         // Manejo de login
-        loginForm.onsubmit = e => {
+        loginForm.onsubmit = async e => {
             e.preventDefault();
             loginError.classList.add('hidden');
             const u = user.value.trim(), p = pass.value.trim();
-            if (u === 'admin' && p === 'admin') {
-                currentUser = { username: u, role: 'root' };
-                lblUser.textContent = u;
+            try {
+                const res = await fetch('/login', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username: u, password: p })
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    loginError.textContent = data.msg || 'Credenciales incorrectas';
+                    loginError.classList.remove('hidden');
+                    return;
+                }
+                authToken = data.token;
+                currentUser = { username: data.username, role: data.role };
+                lblUser.textContent = data.username;
                 loadingOverlay.classList.remove('hidden');
                 setTimeout(() => {
                     loginCard.classList.add('hidden');
@@ -438,8 +467,8 @@
                     initMenu();
                     document.querySelector('#menu button').click();
                 }, 600);
-            } else {
-                loginError.textContent = 'Credenciales incorrectas';
+            } catch {
+                loginError.textContent = 'Error de conexión';
                 loginError.classList.remove('hidden');
             }
         };

--- a/PanelDomoticoWeb/util/sendSerial.mjs
+++ b/PanelDomoticoWeb/util/sendSerial.mjs
@@ -15,8 +15,10 @@ export default async function sendSerial(comando) {
     return new Promise((resolve, reject) => {
         // Si aún no se ha abierto el puerto, lo abrimos
         if (!port) {
-            // CAMBIA 'COM5' por tu puerto real (ej. '/dev/ttyUSB0' en Linux)
-            port = new SerialPort('COM5', {
+            // Usa el puerto definido por la variable de entorno SERIAL_PORT o COM5 por defecto
+            const portName = process.env.SERIAL_PORT || 'COM5';
+            console.log(`Conectando al puerto serial ${portName}`);
+            port = new SerialPort(portName, {
                 baudRate: 9600,
                 autoOpen: false
             });


### PR DESCRIPTION
## Summary
- fix imports in command modules
- allow setting serial port via `SERIAL_PORT` env variable
- implement real login and command calls in the frontend

## Testing
- `npm ci`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68470234f6a08333a3c85e96fb8158e6