### PR TITLE
Fix getDb import and serial command modules

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -1,4 +1,4 @@
-﻿imp// app.mjs
+// app.mjs
 import express from 'express';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';

--- a/PanelDomoticoWeb/comandos/abrir.mjs
+++ b/PanelDomoticoWeb/comandos/abrir.mjs
@@ -1,4 +1,4 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
     const respuesta = await sendSerial(serial, 'abrir');

--- a/PanelDomoticoWeb/comandos/borrar.mjs
+++ b/PanelDomoticoWeb/comandos/borrar.mjs
@@ -1,7 +1,7 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
-    // Aquí como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
+    // AquÃ­ como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
     const id = 5;
     return await sendSerial(serial, `borrar ${id}`);
 }

--- a/PanelDomoticoWeb/comandos/cerrar.mjs
+++ b/PanelDomoticoWeb/comandos/cerrar.mjs
@@ -1,4 +1,4 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
     const respuesta = await sendSerial(serial, 'cerrar');

--- a/PanelDomoticoWeb/comandos/distancia.mjs
+++ b/PanelDomoticoWeb/comandos/distancia.mjs
@@ -1,4 +1,4 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
     return await sendSerial(serial, 'distancia');

--- a/PanelDomoticoWeb/comandos/enrolar.mjs
+++ b/PanelDomoticoWeb/comandos/enrolar.mjs
@@ -1,7 +1,7 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
-    // Aquí como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
+    // AquÃ­ como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
     const id = 5;
     return await sendSerial(serial, `enrolar ${id}`);
 }

--- a/PanelDomoticoWeb/comandos/huella.mjs
+++ b/PanelDomoticoWeb/comandos/huella.mjs
@@ -1,4 +1,4 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
     return await sendSerial(serial, 'huella');

--- a/PanelDomoticoWeb/comandos/pir.mjs
+++ b/PanelDomoticoWeb/comandos/pir.mjs
@@ -1,4 +1,4 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
     return await sendSerial(serial, 'pir');

--- a/PanelDomoticoWeb/comandos/rfid.mjs
+++ b/PanelDomoticoWeb/comandos/rfid.mjs
@@ -1,4 +1,4 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
     return await sendSerial(serial, 'rfid');

--- a/PanelDomoticoWeb/comandos/voltaje.mjs
+++ b/PanelDomoticoWeb/comandos/voltaje.mjs
@@ -1,4 +1,4 @@
-import { sendSerial } from '../util/sendSerial.mjs';
+import sendSerial from '../util/sendSerial.mjs';
 
 export default async function (serial) {
     return await sendSerial(serial, 'voltaje');

--- a/PanelDomoticoWeb/db.js
+++ b/PanelDomoticoWeb/db.js
@@ -8,12 +8,21 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+let dbInstance;
+
 // Función para abrir la conexión
 export async function openDb() {
-    return open({
-        filename: path.join(__dirname, 'edusec.db'),
-        driver: sqlite3.Database
-    });
+    if (!dbInstance) {
+        dbInstance = await open({
+            filename: path.join(__dirname, 'edusec.db'),
+            driver: sqlite3.Database
+        });
+    }
+    return dbInstance;
+}
+
+export function getDb() {
+    return dbInstance;
 }
 
 // Al inicializar la app, creamos tablas si no existen


### PR DESCRIPTION
## Summary
- remove stray characters in `app.mjs`
- keep a singleton database connection and export `getDb`
- fix command modules to import `sendSerial` correctly

## Testing
- `npm start --silent`

------
https://chatgpt.com/codex/tasks/task_e_68476f4e4fb08333a91933298141f32d