### PR TITLE
Fix toggle state when last user deactivation fails

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -453,7 +453,12 @@ document.addEventListener("DOMContentLoaded", () => {
                 try {
                     await api(`/users/${id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ activo }) });
                     loadUsers();
-                } catch (err) { toast(err.message); }
+                } catch (err) {
+                    toast(err.message);
+                    // revert visual toggle if update failed
+                    e.target.checked = !e.target.checked;
+                    loadUsers();
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- keep the toggle checked when the backend rejects user deactivation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848c8d70b488333af8aacea33e12456