### PR TITLE
Refine Monitoreo card colors

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -26,10 +26,13 @@ document.addEventListener("DOMContentLoaded", () => {
             const ok = status.toUpperCase() !== 'NO';
             const label = ok ? 'Operativo' : 'Fallo';
             const icon = ok ? '✅' : '❌';
-            const cls = ok ? 'border-green-400 text-green-700 bg-green-50' : 'border-red-400 text-red-700 bg-red-50';
+            const cls = ok ? 'module-ok' : 'module-fail';
             return `
             <div class="relative">
-              ${card('cpu', name, `<span class=\"flex items-center gap-1\">${icon} ${label}</span>`, `${cls} border module-card`)}
+              <div class="module-card ${cls} shadow p-6 space-y-2">
+                <div class="flex items-center gap-2"><i data-feather="cpu"></i><h4 class="font-bold">${name}</h4></div>
+                <div class="module-status text-sm"><span class="text-lg">${icon}</span><span>${label}</span></div>
+              </div>
               <button onclick="verifyModule('${name}', this)" class="absolute bottom-2 right-2 btn btn-sm verify-btn">Verificar</button>
             </div>`;
         }

--- a/PanelDomoticoWeb/public/style.css
+++ b/PanelDomoticoWeb/public/style.css
@@ -178,6 +178,23 @@ body {
     transition: all 0.2s ease-in-out;
 }
 
+.module-status {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-weight: 500;
+}
+
+.module-ok {
+    background-color: #16a34a; /* green-600 */
+    color: white;
+}
+
+.module-fail {
+    background-color: #dc2626; /* red-600 */
+    color: white;
+}
+
 .verify-btn {
     transition: all 0.2s ease-in-out;
 }


### PR DESCRIPTION
## Summary
- improve visual style for "Monitoreo" module cards
- add CSS helpers for OK/fail states and status row

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848d3f0b2a88333a0fb9fb308820fca