### PR TITLE
Fix rgb command handling

### DIFF
--- a/arduino/EduSecMega/EduSecMega.ino
+++ b/arduino/EduSecMega/EduSecMega.ino
@@ -211,11 +211,11 @@ void loop() {
   }
   else if (cmd.startsWith("rgb ")) {
     String c = cmd.substring(4);
-    if (c == "red")      setRGB(255,0,0);
-    else if (c == "green") setRGB(0,255,0);
-    else if (c == "blue")  setRGB(0,0,255);
-    else if (c == "off")   rgbOff();
-    Serial.println("RGB listo");
+    if (c == "red")      { setRGB(255,0,0); Serial.println("RGB listo"); }
+    else if (c == "green") { setRGB(0,255,0); Serial.println("RGB listo"); }
+    else if (c == "blue")  { setRGB(0,0,255); Serial.println("RGB listo"); }
+    else if (c == "off")   { rgbOff(); Serial.println("RGB listo"); }
+    else Serial.println(F("rgb inválido"));
   }
   else if (cmd == "leertemp") {
     sensors.requestTemperatures();


### PR DESCRIPTION
## Summary
- improve RGB command handling in `EduSecMega.ino`
- print an error when the color is unrecognized and skip the "RGB listo" message

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848d44a9a308333a6d3e3b03a030a9b