### PR TITLE
Reduce module card color saturation

### DIFF
--- a/PanelDomoticoWeb/public/style.css
+++ b/PanelDomoticoWeb/public/style.css
@@ -186,12 +186,12 @@ body {
 }
 
 .module-ok {
-    background-color: #16a34a; /* green-600 */
+    background-color: #4caf50; /* success color */
     color: white;
 }
 
 .module-fail {
-    background-color: #dc2626; /* red-600 */
+    background-color: #f44336; /* error color */
     color: white;
 }
 


### PR DESCRIPTION
## Summary
- adjust module card status colors to softer tones for success and error

## Testing
- `npm test` *(fails: Missing script)*
- `cd PanelDomoticoWeb && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848d7112b3c8333b2158cb10fe7b2ce