### PR TITLE
Revamp module monitoring interface

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -24,16 +24,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
         function moduleCard(name, status) {
             const ok = status.toUpperCase() !== 'NO';
-            const label = ok ? 'Operativo' : 'Fallo';
-            const icon = ok ? '✅' : '❌';
             const cls = ok ? 'module-ok' : 'module-fail';
+            const stateCls = ok ? 'operational' : 'faulty';
+            const label = ok ? 'Operativo' : 'Fallo';
             return `
-            <div class="relative">
-              <div class="module-card ${cls} shadow p-6 space-y-2">
-                <div class="flex items-center gap-2"><i data-feather="cpu"></i><h4 class="font-bold">${name}</h4></div>
-                <div class="module-status text-sm"><span class="text-lg">${icon}</span><span>${label}</span></div>
+            <div class="module-card ${cls} shadow">
+              <div class="flex items-start justify-between">
+                <div class="flex items-center gap-2">
+                  <i data-feather="cpu" class="module-icon"></i>
+                  <h4 class="module-title">${name}</h4>
+                </div>
+                <span class="status ${stateCls}">${label}</span>
               </div>
-              <button onclick="verifyModule('${name}', this)" class="absolute bottom-2 right-2 btn btn-sm verify-btn">Verificar</button>
+              <button onclick="verifyModule('${name}', this)" class="verify-btn btn btn-sm mt-4 self-end">Verificar</button>
             </div>`;
         }
 

--- a/PanelDomoticoWeb/public/style.css
+++ b/PanelDomoticoWeb/public/style.css
@@ -168,14 +168,20 @@ body {
 /* Layout for module cards */
 .module-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
     gap: 1.5rem;
 }
 
 /* Sensor/module card enhancements */
 .module-card {
     border-radius: 0.75rem;
-    transition: all 0.2s ease-in-out;
+    border: 1px solid transparent;
+    padding: 1rem;
+    transition: background-color .2s, border-color .2s;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-width: 15rem;
 }
 
 .module-status {
@@ -183,29 +189,62 @@ body {
     align-items: center;
     gap: 0.25rem;
     font-weight: 500;
+    font-size: 0.85rem;
 }
 
 .module-ok {
-    background-color: #4caf50; /* success color */
-    color: white;
+    background-color: #1e4426;
+    border-color: #28a745;
+    color: #28a745;
 }
 
 .module-fail {
-    background-color: #f44336; /* error color */
-    color: white;
+    background-color: #451717;
+    border-color: #dc3545;
+    color: #dc3545;
 }
 
 .verify-btn {
-    transition: all 0.2s ease-in-out;
+    transition: box-shadow .2s, transform .2s;
 }
 
 .verify-btn:hover {
-    filter: brightness(1.05);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    transform: translateY(-1px);
 }
 
 .verify-btn:active {
     transform: scale(0.97);
 }
 
+
+
+/* Status pills */
+.status {
+    border-radius: 12px;
+    padding: 0.2rem 0.6rem;
+    font-weight: 500;
+    transition: background-color 0.3s ease;
+}
+.status.operational {
+    background: rgba(40, 167, 69, 0.1);
+    color: #28a745;
+}
+.status.faulty {
+    background: rgba(220, 53, 69, 0.1);
+    color: #dc3545;
+}
+
+.module-icon {
+    transition: transform .2s;
+    stroke-width: 2;
+}
+.module-card:hover .module-icon {
+    transform: scale(1.05);
+}
+
+.module-title {
+    font-weight: 700;
+    font-size: 1.1rem;
+}
 


### PR DESCRIPTION
## Summary
- refresh Monitoreo UI
- use responsive 240px grid and modern pill status tags
- theme module cards based on operational status

## Testing
- `npm --version`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684905bff4408333a9d78a663fd68fed