### PR TITLE
Add log query endpoint and use it on access tab

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -99,6 +99,28 @@ async function cargarComandos() {
 }
 await cargarComandos();
 
+// ———————— RUTA PARA OBTENER LOGS POR FECHA ————————
+app.get('/logs/:date', authenticateToken, async (req, res) => {
+    const { date } = req.params;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        return res.status(400).json({ msg: 'Fecha inválida' });
+    }
+    try {
+        const rows = await db.all(
+            `SELECT logs.timestamp, logs.accion, logs.detalle, usuarios.username
+               FROM logs
+               LEFT JOIN usuarios ON logs.usuario_id = usuarios.id
+              WHERE date(logs.timestamp) = ?
+           ORDER BY logs.timestamp ASC`,
+            [date]
+        );
+        return res.json(rows);
+    } catch (err) {
+        console.error('Error en GET /logs/:date:', err);
+        return res.status(500).json({ msg: 'Error interno' });
+    }
+});
+
 // ———————— RUTA PROTEGIDA /comando/:accion ————————
 app.get('/comando/:accion', authenticateToken, async (req, res) => {
     const accion = req.params.accion;


### PR DESCRIPTION
## Summary
- add `/logs/:date` route for retrieving log entries by day
- fetch logs in the access table instead of using placeholder events

## Testing
- `npm test` *(fails: Missing script)*
- `npm run --silent --prefix PanelDomoticoWeb start` *(server starts then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_6849072bc4b883338631ce601bd3764d