### PR TITLE
Add consumption endpoint and dynamic power updates

### DIFF
--- a/PanelDomoticoWeb/comandos/consumo.mjs
+++ b/PanelDomoticoWeb/comandos/consumo.mjs
@@ -1,0 +1,5 @@
+import sendSerial from '../util/sendSerial.mjs';
+
+export default async function () {
+    return await sendSerial('consumo');
+}


### PR DESCRIPTION
## Summary
- show mains status dynamically instead of hard-coded text
- implement refreshConsumption polling function and updateVoltage improvements
- call refreshConsumption in polling loops
- expose new `/comando/consumo` handler

## Testing
- `npm test --silent`
- `npm run lint --silent`
- `node PanelDomoticoWeb/app.mjs` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6849073025448333bf6eacf0e9cee4c6