### PR TITLE
Expose serial port via env variable

### DIFF
--- a/PanelDomoticoWeb/package.json
+++ b/PanelDomoticoWeb/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "app.mjs",
   "scripts": {
-    "start": "node app.mjs",
+    "start": "SERIAL_PORT=COM5 node app.mjs",
     "recover": "node util/recoverRoot.mjs"
   },
   "dependencies": {

--- a/PanelDomoticoWeb/util/sendSerial.mjs
+++ b/PanelDomoticoWeb/util/sendSerial.mjs
@@ -15,8 +15,10 @@ export default async function sendSerial(comando) {
     return new Promise((resolve, reject) => {
         // Si aún no se ha abierto el puerto, lo abrimos
         if (!port) {
-            // CAMBIA 'COM5' por tu puerto real (ej. '/dev/ttyUSB0' en Linux)
-            port = new SerialPort('COM5', {
+            // Puerto serie, configurable via la variable de entorno SERIAL_PORT
+            // (por defecto 'COM5')
+            const path = process.env.SERIAL_PORT || 'COM5';
+            port = new SerialPort(path, {
                 baudRate: 9600,
                 autoOpen: false
             });

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ This repository contains a simple Node.js backend and a web-based front end for 
 
 ```bash
 npm install
-node PanelDomoticoWeb/app.mjs
+SERIAL_PORT=/dev/ttyUSB0 node PanelDomoticoWeb/app.mjs
 ```
-
-The application serves the contents of `PanelDomoticoWeb/public`. Open `http://localhost:3000` after starting the server.
+The `SERIAL_PORT` variable should point to the Arduino's serial device.
+If omitted it defaults to `COM5`. The application serves the contents of
+`PanelDomoticoWeb/public`. Open `http://localhost:3000` after starting the
+server.
 
 ## Design Overview
 


### PR DESCRIPTION
## Summary
- allow passing serial device path through `SERIAL_PORT` env var
- document `SERIAL_PORT` usage in README
- set default port in start script

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684907317a64833397576ad2425a8b04