### PR TITLE
Allow server to run without Arduino

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -6,6 +6,7 @@ import fs from 'fs/promises';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
 import { getDb, initDb } from './db.js';
+import { isArduinoAvailable } from './util/sendSerial.mjs';
 
 // ———————— CONFIGURACIONES BÁSICAS ————————
 const __filename = fileURLToPath(import.meta.url);
@@ -162,6 +163,11 @@ app.get('/huellas', authenticateToken, async (req, res) => {
         console.error('Error en /huellas:', err);
         return res.status(500).json({ msg: 'Error interno' });
     }
+});
+
+// ———————— ESTADO DEL ARDUINO ————————
+app.get('/status/arduino', (req, res) => {
+    res.json({ available: isArduinoAvailable() });
 });
 
 // ———————— CRUD DE USUARIOS (/users) ————————

--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -326,12 +326,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
 const applyBtnStyle = () => {};
 
-        const toast = msg => {
+        const toast = (msg, duration = 3000) => {
             const t = document.createElement('div');
-            t.className = 'bg-slate-800 text-white px-4 py-2 rounded shadow';
-            t.textContent = msg;
+            t.className = 'bg-slate-800 text-white px-4 py-2 rounded shadow flex items-center gap-2';
+            const span = document.createElement('span');
+            span.textContent = msg;
+            const btn = document.createElement('button');
+            btn.innerHTML = '<i data-feather="x"></i>';
+            btn.onclick = () => t.remove();
+            t.appendChild(span);
+            t.appendChild(btn);
             toastContainer.appendChild(t);
-            setTimeout(() => t.remove(), 3000);
+            feather.replace();
+            if (duration !== null) setTimeout(() => t.remove(), duration);
         };
 
         function clockTick() {
@@ -615,6 +622,9 @@ const applyBtnStyle = () => {};
                     document.querySelector('#menu button').click();
                     startPolling();
                     checkAllModules().then(updateModulesSummary);
+                    api('/status/arduino').then(s => {
+                        if (!s.available) toast('⚠️ Arduino no conectado', null);
+                    }).catch(() => {});
                 }, 600);
             } catch (err) {
                 loginError.textContent = err.message;


### PR DESCRIPTION
## Summary
- handle missing serial port gracefully
- expose `/status/arduino` endpoint
- update UI toast helper and show warning when Arduino is absent

## Testing
- `npm install`
- `npm start` *(fails: SerialPort.list error but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_68490d969ba48333a17e27c5305fd158