### PR TITLE
Update start script and README instructions

### DIFF
--- a/PanelDomoticoWeb/package.json
+++ b/PanelDomoticoWeb/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "app.mjs",
   "scripts": {
-    "start": "SERIAL_PORT=COM5 node app.mjs",
+    "start": "node app.mjs",
     "recover": "node util/recoverRoot.mjs"
   },
   "dependencies": {

--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ This repository contains a simple Node.js backend and a web-based front end for 
 
 ```bash
 npm install
-SERIAL_PORT=/dev/ttyUSB0 node PanelDomoticoWeb/app.mjs
+
+# Unix/macOS
+SERIAL_PORT=/dev/ttyUSB0 npm start
+
+# Windows (cmd)
+set SERIAL_PORT=COM5 && npm start
 ```
-The `SERIAL_PORT` variable should point to the Arduino's serial device.
-If omitted it defaults to `COM5`. The application serves the contents of
+The `SERIAL_PORT` variable should point to the Arduino's serial device. If
+omitted the app defaults to `COM5`. The application serves the contents of
 `PanelDomoticoWeb/public`. Open `http://localhost:3000` after starting the
 server.
 


### PR DESCRIPTION
## Summary
- simplify the `npm start` script to just run `node app.mjs`
- clarify how to set `SERIAL_PORT` on Unix/macOS and Windows
- note the COM5 default

## Testing
- `npm test --silent` (root)
- `npm test --silent` (PanelDomoticoWeb)

------
https://chatgpt.com/codex/tasks/task_e_6849104ccce8833390ad691b9e74c358