### PR TITLE
Enable periodic module monitoring

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -321,6 +321,7 @@ document.addEventListener("DOMContentLoaded", () => {
             if (id === 'home') renderSparkline();
             if (id === 'cuentas') loadUsers();
             if (id === 'acceso') updateAccessTable(new Date().toISOString().substring(0, 10));
+            if (id === 'monitoreo') startModuleMonitoring();
         }
 
 


### PR DESCRIPTION
## Summary
- start monitoring hardware modules when entering the Monitoreo section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68490cfa9af08333b7abd41480de93d9