### PR TITLE
Load fingerprints when admin panel visible

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -511,7 +511,12 @@ const applyBtnStyle = () => {};
         }
         function toggleFingerAdmin() {
             const d = document.getElementById('fingerAdmin');
-            if (d) d.classList.toggle('hidden');
+            if (!d) return;
+            const wasHidden = d.classList.contains('hidden');
+            d.classList.toggle('hidden');
+            if (wasHidden && !d.classList.contains('hidden')) {
+                loadHuellas();
+            }
         }
         async function updateAccessTable(dateStr) {
             document.getElementById('accessContainer').innerHTML = await accessTableHTML(dateStr);


### PR DESCRIPTION
## Summary
- load fingerprint list when admin panel is shown

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68490cfb92a883339588feaf246da025