### PR TITLE
Enable log export to CSV

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -516,8 +516,26 @@ const applyBtnStyle = () => {};
         async function updateAccessTable(dateStr) {
             document.getElementById('accessContainer').innerHTML = await accessTableHTML(dateStr);
         }
-        function exportAccessCSV() {
-            toast('Exportando CSV... (simulado)');
+        async function exportAccessCSV() {
+            const date = document.getElementById('filterDate').value;
+            if (!date) return;
+            try {
+                const res = await fetch(`/logs/${date}/csv`, {
+                    headers: { 'Authorization': `Bearer ${jwtToken}` }
+                });
+                if (!res.ok) throw new Error('Error exportando CSV');
+                const blob = await res.blob();
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `logs_${date}.csv`;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+            } catch (err) {
+                toast(err.message);
+            }
         }
         const moduleActions = {
             'PIR Sensor': 'pir',


### PR DESCRIPTION
## Summary
- implement backend endpoint `/logs/:date/csv` that streams logs as CSV
- hook frontend `Exportar CSV` button to download CSV file

## Testing
- `node -c PanelDomoticoWeb/app.mjs`
- `node -c PanelDomoticoWeb/public/panel.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68490cfc2f048333b8c79f3cebbcb686