### PR TITLE
Add central alert for Arduino disconnection

### DIFF
--- a/PanelDomoticoWeb/public/index.html
+++ b/PanelDomoticoWeb/public/index.html
@@ -38,6 +38,14 @@
         <div class="text-white text-xl animate-pulse">Cargando panel…</div>
     </div>
 
+    <!-- Alerta Arduino -->
+    <div id="arduinoAlert" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden z-50">
+        <div class="alert-critical p-6 rounded-lg shadow w-80 text-center space-y-4">
+            <p class="text-lg font-semibold">⚠️ Arduino no conectado</p>
+            <button id="arduinoAlertClose" class="btn btn-danger w-full">Cerrar</button>
+        </div>
+    </div>
+
     <!-- PANEL PRINCIPAL -->
     <div id="panel" class="hidden h-full flex overflow-hidden">
         <!-- SIDEBAR -->

--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -12,6 +12,16 @@ document.addEventListener("DOMContentLoaded", () => {
     const toggleSidebar = document.getElementById("toggleSidebar");
     const content = document.getElementById("content");
     const clockNow = document.getElementById("clockNow");
+    const arduinoAlert = document.getElementById("arduinoAlert");
+    const arduinoAlertClose = document.getElementById("arduinoAlertClose");
+
+    if (arduinoAlertClose) {
+        arduinoAlertClose.onclick = () => arduinoAlert.classList.add('hidden');
+    }
+
+    const showArduinoAlert = () => {
+        if (arduinoAlert) arduinoAlert.classList.remove('hidden');
+    };
 
         // Generadores de tarjetas
         function card(icon, title, value, cls = "") {
@@ -647,7 +657,7 @@ const applyBtnStyle = () => {};
                     startPolling();
                     checkAllModules().then(updateModulesSummary);
                     api('/status/arduino').then(s => {
-                        if (!s.available) toast('⚠️ Arduino no conectado', null);
+                        if (!s.available) showArduinoAlert();
                     }).catch(() => {});
                 }, 600);
             } catch (err) {

--- a/PanelDomoticoWeb/public/style.css
+++ b/PanelDomoticoWeb/public/style.css
@@ -230,6 +230,12 @@ body {
     color: #dc3545;
 }
 
+.alert-critical {
+    background-color: #451717;
+    border: 1px solid #dc3545;
+    color: #dc3545;
+}
+
 .verify-btn {
     transition: box-shadow .2s, transform .2s;
 }


### PR DESCRIPTION
## Summary
- add a dismissable Arduino alert overlay to the UI
- provide styles for critical alerts
- show the new alert instead of a toast when Arduino is missing

## Testing
- `node --check PanelDomoticoWeb/public/panel.js`
- `node --check PanelDomoticoWeb/app.mjs`

------
https://chatgpt.com/codex/tasks/task_e_684913bfe99883338f3c551595f1d2fb