### PR TITLE
Fix numeric parsing when Arduino absent

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -408,12 +408,19 @@ const applyBtnStyle = () => {};
             const el = document.getElementById('modulesSummary');
             if (el) el.textContent = modulesSummary();
         }
+        function parseNumber(str) {
+            if (!str || /(no disponible|error|timeout|sin respuesta)/i.test(str)) {
+                return null;
+            }
+            const m = /([-+]?\d+(?:\.\d+)?)/.exec(str);
+            return m ? parseFloat(m[1]) : null;
+        }
+
         async function refreshTemp() {
             try {
                 const data = await api('/comando/leertemp');
-                const m = /([-+]?\d+\.?\d*)/.exec(data.resultado || '');
-                if (m) {
-                    const val = parseFloat(m[1]);
+                const val = parseNumber(data.resultado);
+                if (val !== null) {
                     updateTemp(val);
                     tempHistory.push(val);
                     if (tempHistory.length > 12) tempHistory.shift();
@@ -429,9 +436,8 @@ const applyBtnStyle = () => {};
         async function refreshVoltage() {
             try {
                 const data = await api('/comando/voltaje');
-                const m = /([-+]?\d+\.?\d*)/.exec(data.resultado || '');
-                if (m) {
-                    const v = parseFloat(m[1]);
+                const v = parseNumber(data.resultado);
+                if (v !== null) {
                     updateVoltage(v);
                 } else {
                     updateVoltage(null);
@@ -446,9 +452,9 @@ const applyBtnStyle = () => {};
         async function refreshConsumption() {
             try {
                 const data = await api('/comando/consumo');
-                const m = /([-+]?\d+\.?\d*)/.exec(data.resultado || '');
-                if (m) {
-                    updateConsumption(parseFloat(m[1]));
+                const c = parseNumber(data.resultado);
+                if (c !== null) {
+                    updateConsumption(c);
                 } else {
                     updateConsumption(null);
                 }
@@ -496,9 +502,8 @@ const applyBtnStyle = () => {};
         async function refreshVoltage() {
             try {
                 const data = await api('/comando/voltaje');
-                const m = /([-+]?\d+\.?\d*)/.exec(data.resultado || '');
-                if (m) {
-                    const v = parseFloat(m[1]);
+                const v = parseNumber(data.resultado);
+                if (v !== null) {
                     updateVoltage(v);
                 } else {
                     updateVoltage(null);
@@ -513,9 +518,9 @@ const applyBtnStyle = () => {};
         async function refreshConsumption() {
             try {
                 const data = await api('/comando/consumo');
-                const m = /([-+]?\d+\.?\d*)/.exec(data.resultado || '');
-                if (m) {
-                    updateConsumption(parseFloat(m[1]));
+                const c = parseNumber(data.resultado);
+                if (c !== null) {
+                    updateConsumption(c);
                 } else {
                     updateConsumption(null);
                 }


### PR DESCRIPTION
## Summary
- avoid extracting numbers from error messages in panel

## Testing
- `node -c public/panel.js`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68491522c61483339da09672e7832c70