### PR TITLE
Refine access log table and CSV export

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -102,6 +102,9 @@ await cargarComandos();
 
 // ———————— RUTA PARA DESCARGAR LOGS EN CSV ————————
 app.get('/logs/:date/csv', authenticateToken, async (req, res) => {
+    if (req.user.role !== 'root') {
+        return res.status(403).json({ msg: 'Acceso denegado: solo root' });
+    }
     const { date } = req.params;
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
         return res.status(400).json({ msg: 'Fecha inválida' });


### PR DESCRIPTION
## Summary
- filter log entries on the access page to only door events
- create CSV on the client side and expose helper functions
- limit CSV download endpoint to root accounts

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_684918f1216c8333baaa33ec75124569