### PR TITLE
Fix Estatus module verification display

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -651,17 +651,16 @@ const applyBtnStyle = () => {};
 
         async function checkAllModules() {
             for (const mod in moduleActions) {
-                await verifyModule(mod);
+                await verifyModule(mod, null, false);
             }
         }
 
        function startModuleMonitoring() {
-           setCheckingStatuses();
-            checkAllModules();
             clearInterval(moduleInterval);
+            checkAllModules();
             moduleInterval = setInterval(checkAllModules, 60000);
         }
-        async function verifyModule(mod, btn) {
+        async function verifyModule(mod, btn, showChecking = true) {
             if (btn) {
                 btn.disabled = true;
                 btn.innerHTML = '<span class="spinner"></span>';
@@ -671,7 +670,7 @@ const applyBtnStyle = () => {};
                 if (!accion) throw new Error('No soportado');
                 const card = document.querySelector(`.module-card[data-module="${mod}"]`);
                 const span = card ? card.querySelector('[data-status]') : null;
-                if (span) {
+                if (span && showChecking) {
                     span.classList.add('checking');
                     span.classList.remove('operational', 'faulty');
                     span.textContent = 'Verificando...';


### PR DESCRIPTION
## Summary
- avoid setting `Verificando` status for modules on every section load
- run automatic checks silently

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68492218827c833382d878280f65bae9