### PR TITLE
Add Monitoreo dashboard

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -283,6 +283,43 @@ document.addEventListener("DOMContentLoaded", () => {
               </div>
             </section>`,
 
+            monitoreo: () => `
+            <section class="space-y-6">
+              <h3 class="section-title border-b border-slate-200 dark:border-slate-700 pb-2"><i data-feather="eye"></i>Monitoreo</h3>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-6 space-y-4">
+                  <h4 class="font-bold">Estado del Sistema</h4>
+                  <div class="flex items-center gap-2">
+                    <span id="systemStatusText" class="font-medium text-green-600">ÁREA LIBRE</span>
+                    <span id="systemIndicator" class="w-3 h-3 rounded-full bg-green-500"></span>
+                  </div>
+                  <button id="toggleArmBtn" class="btn w-full flex items-center justify-center gap-2"><i data-feather="lock"></i>Armar Sistema</button>
+                </div>
+                <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-6 space-y-4">
+                  <h4 class="font-bold">Sensores Activos</h4>
+                  <div class="flex items-center justify-between">
+                    <span>Sensor de Movimiento (PIR)</span>
+                    <span id="pirStatus" class="status inactive">Sin Movimiento</span>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <span>Sensor de Puerta (Ultrasonido)</span>
+                    <span id="doorStatus" class="status inactive">Puerta Cerrada</span>
+                  </div>
+                </div>
+                <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-6 space-y-4">
+                  <h4 class="font-bold">Notificaciones</h4>
+                  <div class="flex items-center justify-between">
+                    <span class="flex items-center gap-1"><i data-feather="volume-2"></i>Buzzer:</span>
+                    <span id="buzzerStatus" class="status inactive">Inactivo</span>
+                  </div>
+                </div>
+                <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-6 space-y-4">
+                  <h4 class="font-bold">Registro de Eventos de Seguridad</h4>
+                  <div id="securityLog" class="space-y-1 max-h-40 overflow-y-auto text-sm"></div>
+                </div>
+              </div>
+            </section>`,
+
             energia: () => `
             <section class="space-y-6">
               <h3 class="section-title border-b border-slate-200 dark:border-slate-700 pb-2"><i data-feather="zap"></i>Alimentación</h3>
@@ -327,6 +364,7 @@ document.addEventListener("DOMContentLoaded", () => {
             ["home", "home", "Inicio"],
             ["acceso", "lock", "Acceso principal"],
             ["estatus", "activity", "Estatus"],
+            ["monitoreo", "eye", "Monitoreo"],
             ["energia", "zap", "Alimentación"],
             ["cuentas", "users", "Cuentas"],
             ["acerca", "info", "Acerca"]
@@ -360,6 +398,7 @@ document.addEventListener("DOMContentLoaded", () => {
             if (id === 'cuentas') loadUsers();
             if (id === 'acceso') updateAccessTable(new Date().toISOString().substring(0, 10));
             if (id === 'estatus') startModuleMonitoring();
+            if (id === 'monitoreo') startSecurityMonitoring();
         }
 
 
@@ -649,16 +688,111 @@ const applyBtnStyle = () => {};
             }
         }
 
-        async function checkAllModules() {
-            for (const mod in moduleActions) {
-                await verifyModule(mod, null, false);
+       async function checkAllModules() {
+           for (const mod in moduleActions) {
+               await verifyModule(mod, null, false);
+           }
+       }
+
+      function startModuleMonitoring() {
+           clearInterval(moduleInterval);
+           checkAllModules();
+           moduleInterval = setInterval(checkAllModules, 60000);
+       }
+
+        function updateSystemStateUI() {
+            const txt = document.getElementById('systemStatusText');
+            const ind = document.getElementById('systemIndicator');
+            const btn = document.getElementById('toggleArmBtn');
+            if (!txt || !ind || !btn) return;
+            if (systemArmed) {
+                txt.textContent = 'ZONA SEGURA';
+                txt.className = 'font-medium text-red-500';
+                ind.className = 'w-3 h-3 rounded-full bg-red-500';
+                btn.innerHTML = '<i data-feather="unlock"></i>Desarmar Sistema';
+            } else {
+                txt.textContent = 'ÁREA LIBRE';
+                txt.className = 'font-medium text-green-600';
+                ind.className = 'w-3 h-3 rounded-full bg-green-500';
+                btn.innerHTML = '<i data-feather="lock"></i>Armar Sistema';
             }
+            feather.replace();
         }
 
-       function startModuleMonitoring() {
-            clearInterval(moduleInterval);
-            checkAllModules();
-            moduleInterval = setInterval(checkAllModules, 60000);
+        function updatePirUI(active) {
+            const el = document.getElementById('pirStatus');
+            if (!el) return;
+            el.textContent = active ? 'Movimiento Detectado' : 'Sin Movimiento';
+            el.className = 'status ' + (active ? 'faulty' : 'inactive');
+        }
+
+        function updateDoorUI(open) {
+            const el = document.getElementById('doorStatus');
+            if (!el) return;
+            el.textContent = open ? 'Puerta Abierta' : 'Puerta Cerrada';
+            el.className = 'status ' + (open ? 'faulty' : 'inactive');
+        }
+
+        function updateBuzzerUI(active) {
+            const el = document.getElementById('buzzerStatus');
+            if (!el) return;
+            el.textContent = active ? 'Activo' : 'Inactivo';
+            el.className = 'status ' + (active ? 'operational' : 'inactive');
+        }
+
+        function addSecurityLog(msg) {
+            const logEl = document.getElementById('securityLog');
+            if (!logEl) return;
+            const now = new Date().toLocaleTimeString();
+            securityLogs.unshift(`${now} - ${msg}`);
+            if (securityLogs.length > 20) securityLogs.pop();
+            logEl.innerHTML = securityLogs.map(l => `<div class="bg-slate-100 dark:bg-slate-700 rounded px-2 py-1">${l}</div>`).join('');
+        }
+
+        function triggerAlarm() {
+            if (buzzerTimeout) return;
+            updateBuzzerUI(true);
+            api('/comando/alarm').catch(() => {});
+            addSecurityLog('Buzzer activado');
+            buzzerTimeout = setTimeout(() => {
+                updateBuzzerUI(false);
+                buzzerTimeout = null;
+            }, 3000);
+        }
+
+        async function checkSensors() {
+            try {
+                const pirData = await api('/comando/pir');
+                const m = /PIR:\s*(\d+)/i.exec(pirData.resultado || '');
+                const val = m ? parseInt(m[1]) : 0;
+                updatePirUI(val === 1);
+                if (lastPir !== null && val !== lastPir) {
+                    addSecurityLog(`PIR: ${val ? 'Movimiento Detectado' : 'Sin Movimiento'}`);
+                }
+                if (systemArmed && val === 1) triggerAlarm();
+                lastPir = val;
+            } catch (err) { }
+
+            try {
+                const distData = await api('/comando/distancia');
+                const n = /([-+]?\d+(?:\.\d+)?)/.exec(distData.resultado || '');
+                const cm = n ? parseFloat(n[1]) : null;
+                const open = cm !== null ? cm > 10 : false;
+                updateDoorUI(open);
+                if (lastDoorOpen !== null && open !== lastDoorOpen) {
+                    addSecurityLog(`Ultrasonido: ${open ? 'Puerta Abierta' : 'Puerta Cerrada'}`);
+                }
+                if (systemArmed && open) triggerAlarm();
+                lastDoorOpen = open;
+            } catch (err) { }
+        }
+
+        function startSecurityMonitoring() {
+            clearInterval(monitorInterval);
+            updateSystemStateUI();
+            updateBuzzerUI(false);
+            checkSensors();
+            monitorInterval = setInterval(checkSensors, 3000);
         }
         async function verifyModule(mod, btn, showChecking = true) {
             if (btn) {
@@ -704,6 +838,12 @@ const applyBtnStyle = () => {};
         let jwtToken = '';
         let tempHistory = [];
         let tempChart = null;
+        let systemArmed = false;
+        let monitorInterval = null;
+        let buzzerTimeout = null;
+        let lastPir = null;
+        let lastDoorOpen = null;
+        const securityLogs = [];
 
         const api = async (url, opts = {}) => {
             opts.headers = opts.headers || {};
@@ -839,6 +979,9 @@ const applyBtnStyle = () => {};
                     await api(`/users/${id}`, { method: 'DELETE' });
                     loadUsers();
                 } catch (err) { toast(err.message); }
+            } else if (e.target.closest('#toggleArmBtn')) {
+                systemArmed = !systemArmed;
+                updateSystemStateUI();
             }
         });
 

--- a/PanelDomoticoWeb/public/style.css
+++ b/PanelDomoticoWeb/public/style.css
@@ -331,6 +331,10 @@ body {
     background: rgba(37, 99, 235, 0.1);
     color: #2563eb;
 }
+.status.inactive {
+    background: rgba(107, 114, 128, 0.1);
+    color: #6b7280;
+}
 
 .module-icon {
     transition: transform .2s;


### PR DESCRIPTION
## Summary
- add status pill style for inactive items
- implement new Monitoreo section with system arm/disarm, sensor states and log
- include new menu entry and monitoring functions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684923a9aa748333917c948f8f15e921