### PR TITLE
Add Monitoreo dashboard

### DIFF
--- a/PanelDomoticoWeb/public/style.css
+++ b/PanelDomoticoWeb/public/style.css
@@ -331,6 +331,14 @@ body {
     background: rgba(37, 99, 235, 0.1);
     color: #2563eb;
 }
+.status.inactive {
+    background: rgba(107, 114, 128, 0.1);
+    color: #6b7280;
+}
+.status.unavailable {
+    background: rgba(249, 115, 22, 0.1);
+    color: #f97316;
+}
 
 .module-icon {
     transition: transform .2s;


### PR DESCRIPTION
## Summary
- add status pill style for unavailable items
- implement new Monitoreo section with system arm/disarm, sensor states and log
- include new menu entry and monitoring functions
- prevent duplicate Monitoreo menu items

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684923a9aa748333917c948f8f15e921