### PR TITLE
Improve configuration section styles

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -344,7 +344,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 </div>
               </details>
 
-              <details class="details-card">
+              <details class="details-card${simulatedMode ? '' : ' disabled'}" title="Opciones solo disponibles en modo simulado">
                 <summary><span class="flex items-center gap-2">📂 Gestión de Datos (Simulado)</span><i data-feather="chevron-down" class="collapse-icon"></i></summary>
                 <div class="p-4 flex flex-wrap gap-2">
                   <button id="backupBtn" class="btn flex-auto sm:flex-none">Copia de Seguridad</button>
@@ -353,23 +353,23 @@ document.addEventListener("DOMContentLoaded", () => {
                 </div>
               </details>
 
-              <details class="details-card">
+              <details class="details-card${simulatedMode ? '' : ' disabled'}" title="Opciones solo disponibles en modo simulado">
                 <summary><span class="flex items-center gap-2">🧪 Parámetros del Sistema (Simulado)</span><i data-feather="chevron-down" class="collapse-icon"></i></summary>
                 <div class="p-4 space-y-4">
                   <div class="flex flex-wrap items-center gap-2">
                     <label for="sensorInterval" class="flex-1">Intervalo de Sondeo de Sensores (segundos):</label>
-                    <input id="sensorInterval" type="number" class="w-24 px-2 py-1 rounded border border-slate-300 dark:border-slate-600 bg-transparent">
+                    <input id="sensorInterval" type="number" class="input-field w-24">
                     <button id="applySensorInterval" class="btn btn-sm">Aplicar</button>
                   </div>
                   <div class="flex flex-wrap items-center gap-2">
                     <label for="sessionTimeout" class="flex-1">Tiempo de Espera de Sesión Inactiva (minutos):</label>
-                    <input id="sessionTimeout" type="number" class="w-24 px-2 py-1 rounded border border-slate-300 dark:border-slate-600 bg-transparent">
+                    <input id="sessionTimeout" type="number" class="input-field w-24">
                     <button id="applySessionTimeout" class="btn btn-sm">Aplicar</button>
                   </div>
                 </div>
               </details>
 
-              <details class="details-card">
+              <details class="details-card${simulatedMode ? '' : ' disabled'}" title="Opciones solo disponibles en modo simulado">
                 <summary><span class="flex items-center gap-2">🧰 Mantenimiento del Sistema (Simulado)</span><i data-feather="chevron-down" class="collapse-icon"></i></summary>
                 <div class="p-4 flex flex-wrap gap-2">
                   <button id="updateBtn" class="btn flex-auto sm:flex-none">Buscar Actualizaciones</button>
@@ -916,6 +916,7 @@ const applyBtnStyle = () => {};
         let lastPir = null;
         let lastDoorOpen = null;
         const securityLogs = [];
+        let simulatedMode = true;
 
         const api = async (url, opts = {}) => {
             opts.headers = opts.headers || {};

--- a/PanelDomoticoWeb/public/style.css
+++ b/PanelDomoticoWeb/public/style.css
@@ -32,12 +32,12 @@ body {
 }
 
 .section-title {
-    font-weight: 600;
-    font-size: 1.25rem;
+    font-weight: 700;
+    font-size: 1.5rem;
     margin-bottom: 0.5rem;
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.5rem;
 }
 
 .sidebar-collapsed aside {
@@ -123,6 +123,22 @@ body {
 
 .btn-danger:hover {
     background-color: #b91c1c;
+}
+
+/* generic input styling */
+.input-field {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    background-color: #1f2937;
+    color: #f1f5f9;
+    border: 1px solid rgba(255,255,255,0.2);
+    transition: background-color .2s, border-color .2s;
+}
+
+.input-field:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
 }
 
 .text-success {
@@ -366,12 +382,14 @@ body {
 
 /* Collapsible details cards */
 .details-card {
-    background-color: var(--bg-card, #ffffff);
+    background-color: #1f2937;
+    color: #e2e8f0;
     border-radius: 0.5rem;
     padding: 0;
-    box-shadow: 0 1px 3px rgb(0 0 0 / 0.1);
-    border: 1px solid rgb(0 0 0 / 0.05);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     overflow: hidden;
+    transition: background-color .2s, box-shadow .3s;
 }
 
 .details-card summary {
@@ -382,14 +400,21 @@ body {
     cursor: pointer;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
+    font-weight: 600;
+    font-size: 1rem;
+    transition: background-color .2s;
 }
 
 .details-card summary:hover {
-    background-color: rgba(0,0,0,0.03);
+    background-color: rgba(255,255,255,0.05);
+}
+
+.details-card summary:active {
+    background-color: rgba(255,255,255,0.1);
 }
 
 .details-card[open] summary {
-    border-bottom: 1px solid rgb(0 0 0 / 0.05);
+    border-bottom: 1px solid rgba(255,255,255,0.1);
 }
 
 .collapse-icon {
@@ -398,6 +423,27 @@ body {
 
 .details-card[open] .collapse-icon {
     transform: rotate(180deg);
+}
+
+.details-card[open] {
+    background-image: linear-gradient(180deg, #1f2937, #263249);
+    box-shadow: inset 0 2px 4px rgba(0,0,0,0.6);
+}
+
+.details-card.disabled {
+    background-color: #374151;
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.details-card > div {
+    padding: 1rem;
+    animation: cardOpen .3s ease-out;
+}
+
+@keyframes cardOpen {
+    from { opacity: 0; transform: translateY(-0.25rem); }
+    to { opacity: 1; transform: translateY(0); }
 }
 
 


### PR DESCRIPTION
## Summary
- modernize section title style
- restyle collapsible cards in Configuración
- add disabled state for simulated cards and smooth open animation
- standardize dark input fields
- enable simulated mode variable and integrate with cards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68499e88652083338a77e62e97ce5c78