### PR TITLE
Add configurable serial port

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -7,6 +7,7 @@ import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
 import { getDb, initDb } from './db.js';
 import { isArduinoAvailable } from './util/sendSerial.mjs';
+import { readConfig, writeConfig } from './util/config.mjs';
 
 // ———————— CONFIGURACIONES BÁSICAS ————————
 const __filename = fileURLToPath(import.meta.url);
@@ -203,6 +204,20 @@ app.get('/huellas', authenticateToken, async (req, res) => {
 // ———————— ESTADO DEL ARDUINO ————————
 app.get('/status/arduino', (req, res) => {
     res.json({ available: isArduinoAvailable() });
+});
+
+// --------- Ajustes del sistema ---------
+
+app.get('/settings/serial-port', async (req, res) => {
+    const cfg = await readConfig();
+    res.json({ serialPort: cfg.serialPort });
+});
+
+app.post('/settings/serial-port', async (req, res) => {
+    const { serialPort } = req.body;
+    if (!serialPort) return res.status(400).json({ msg: 'serialPort requerido' });
+    await writeConfig({ serialPort });
+    res.json({ msg: 'ok' });
 });
 
 // ———————— CRUD DE USUARIOS (/users) ————————

--- a/PanelDomoticoWeb/config.json
+++ b/PanelDomoticoWeb/config.json
@@ -1,0 +1,3 @@
+{
+  "serialPort": "COM5"
+}

--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -340,6 +340,11 @@ document.addEventListener("DOMContentLoaded", () => {
                   <label class="flex items-center gap-2"><input type="checkbox" id="chkNotifAcc" class="focus-ring-primary">Habilitar Notificaciones de Acceso</label>
                   <label class="flex items-center gap-2"><input type="checkbox" id="chkNotifSec" class="focus-ring-primary">Habilitar Notificaciones de Seguridad</label>
                   <label class="flex items-center gap-2"><input type="checkbox" id="chkNotifSys" class="focus-ring-primary">Habilitar Notificaciones del Sistema</label>
+                  <div class="flex flex-wrap items-center gap-2">
+                    <label for="serialPort" class="flex-1">Puerto Serie:</label>
+                    <input id="serialPort" type="text" class="input-field w-32">
+                    <button id="applySerialPort" class="btn btn-sm">Aplicar</button>
+                  </div>
                   <button id="savePrefsBtn" class="btn mt-2 flex items-center gap-1"><i data-feather="save"></i>Guardar Preferencias</button>
                 </div>
               </div>
@@ -434,6 +439,7 @@ document.addEventListener("DOMContentLoaded", () => {
             if (id === 'acceso') updateAccessTable(new Date().toISOString().substring(0, 10));
             if (id === 'estatus') startModuleMonitoring();
             if (id === 'monitoreo') startSecurityMonitoring();
+            if (id === 'config') loadSerialPort();
         }
 
 
@@ -925,6 +931,16 @@ const applyBtnStyle = () => {};
             }
         }
 
+        async function loadSerialPort() {
+            try {
+                const data = await api('/settings/serial-port');
+                const inp = document.getElementById('serialPort');
+                if (inp) inp.value = data.serialPort || '';
+            } catch {
+                toast('Error cargando configuración');
+            }
+        }
+
         function renderUsers(list) {
             const tbody = document.querySelector('#usersTable tbody');
             if (!tbody) return;
@@ -1021,6 +1037,15 @@ const applyBtnStyle = () => {};
                 toast('Caché limpiada');
             } else if (e.target.closest('#applySensorInterval')) {
                 toast('Intervalo aplicado');
+            } else if (e.target.closest('#applySerialPort')) {
+                const port = document.getElementById('serialPort').value.trim();
+                if (port) {
+                    try {
+                        await api('/settings/serial-port', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ serialPort: port }) });
+                        toast('Puerto actualizado');
+                        await api('/status/arduino').then(s => { if (!s.available) showArduinoAlert(); });
+                    } catch (err) { toast(err.message); }
+                }
             } else if (e.target.closest('#applySessionTimeout')) {
                 toast('Tiempo de espera actualizado');
             } else if (e.target.closest('#updateBtn')) {

--- a/PanelDomoticoWeb/util/config.mjs
+++ b/PanelDomoticoWeb/util/config.mjs
@@ -1,0 +1,30 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const configPath = path.join(__dirname, '..', 'config.json');
+
+const defaultConfig = { serialPort: process.env.SERIAL_PORT || 'COM5' };
+
+export async function readConfig() {
+  try {
+    const data = await fs.readFile(configPath, 'utf8');
+    return { ...defaultConfig, ...JSON.parse(data) };
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      await fs.writeFile(configPath, JSON.stringify(defaultConfig, null, 2));
+      return { ...defaultConfig };
+    }
+    console.error('Error reading config:', err);
+    return { ...defaultConfig };
+  }
+}
+
+export async function writeConfig(newCfg) {
+  const current = await readConfig();
+  const updated = { ...current, ...newCfg };
+  await fs.writeFile(configPath, JSON.stringify(updated, null, 2));
+  return updated;
+}

--- a/PanelDomoticoWeb/util/sendSerial.mjs
+++ b/PanelDomoticoWeb/util/sendSerial.mjs
@@ -1,6 +1,7 @@
 // util/sendSerial.mjs
 import { SerialPort } from 'serialport';
 import { ReadlineParser } from '@serialport/parser-readline';
+import { readConfig } from './config.mjs';
 
 let port;
 let parser;
@@ -10,7 +11,8 @@ let arduinoAvailable = false;
  * Detect if the configured serial port exists.
  */
 export async function checkArduino() {
-    const path = process.env.SERIAL_PORT || 'COM5';
+    const cfg = await readConfig();
+    const path = cfg.serialPort || 'COM5';
     try {
         const ports = await SerialPort.list();
         arduinoAvailable = ports.some(p => p.path === path);
@@ -34,7 +36,8 @@ await checkArduino();
  * @returns {Promise<string>} Respuesta del Arduino como string
  */
 export default async function sendSerial(comando) {
-    const path = process.env.SERIAL_PORT || 'COM5';
+    const cfg = await readConfig();
+    const path = cfg.serialPort || 'COM5';
     if (!arduinoAvailable) {
         await checkArduino();
         if (!arduinoAvailable) {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ omitted the app defaults to `COM5`. The application serves the contents of
 `PanelDomoticoWeb/public`. Open `http://localhost:3000` after starting the
 server.
 
+You can also change the port from the web interface. Visit the "Configuración"
+section and update the **Puerto Serie** field. The chosen value is stored in
+`PanelDomoticoWeb/config.json` so it persists across restarts.
+
 ## Design Overview
 
 The UI includes:


### PR DESCRIPTION
## Summary
- support config file with `serialPort`
- expose serial port GET/POST API endpoints
- read serial port from config when communicating with Arduino
- add UI option under settings to change serial port
- document new setting in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849b12b78e08333ba946dbf2a689da6