### PR TITLE
Rename RFID SS references to SDA

### DIFF
--- a/arduino/EduSecMega/EduSecMega.ino
+++ b/arduino/EduSecMega/EduSecMega.ino
@@ -10,7 +10,7 @@
 #define PIR_PIN      2
 #define TRIG_PIN     8
 #define ECHO_PIN     9
-#define SS_PIN       10
+#define SDA_PIN      10
 #define RST_PIN      11
 #define BUZZER_PIN   7
 #define LED_R        3
@@ -20,7 +20,7 @@
 
 // ----------------------------------------------------------
 Adafruit_Fingerprint finger(&Serial1);  // uses hardware Serial1
-MFRC522 rfid(SS_PIN, RST_PIN);
+MFRC522 rfid(SDA_PIN, RST_PIN);
 OneWire oneWire(ONE_WIRE_BUS);
 DallasTemperature sensors(&oneWire);
 

--- a/arduino/EduSecMega/README.md
+++ b/arduino/EduSecMega/README.md
@@ -12,7 +12,7 @@ single Arduino Mega can handle all commands from the Node.js panel.
 | PIR sensor                          | 2   |
 | Ultrasonic TRIG                     | 8   |
 | Ultrasonic ECHO                     | 9   |
-| RFID SS                             | 10  |
+| RFID SDA                            | 10  |
 | RFID RST                            | 11  |
 | RFID MOSI                           | 51  |
 | RFID MISO                           | 50  |

--- a/arduino/original/A2.ino
+++ b/arduino/original/A2.ino
@@ -2,7 +2,7 @@
    ------------------------------------------
    • PIR en D5
    • Ultrasonido: TRIG→D8, ECHO→D4
-   • RFID RC522: SS=D10, RST=D9, MOSI=D11, MISO=D12, SCK=D13, VCC=3.3V, GND
+   • RFID RC522: SDA=D10, RST=D9, MOSI=D11, MISO=D12, SCK=D13, VCC=3.3V, GND
    • Buzzer pasivo en D7 (directo al pin, sin resistencia)
    • LED RGB (cátodo común) en R→D3, G→D5, B→D6, "-"→GND
 */
@@ -14,9 +14,9 @@ const int PIR_PIN    = 2;
 const int TRIG_PIN   = 8;
 const int ECHO_PIN   = 4;
 
-const int SS_PIN     = 10;
+const int SDA_PIN    = 10;
 const int RST_PIN    = 9;
-MFRC522 rfid(SS_PIN, RST_PIN);
+MFRC522 rfid(SDA_PIN, RST_PIN);
 
 const int BUZZER_PIN = 7;
 const int LED_R      = 3;


### PR DESCRIPTION
## Summary
- rename RFID "SS" pin label to "SDA" in docs and sketches
- update original A2 prototype sketch accordingly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68499c5a7c4883338439f84b76a673e9