### PR TITLE
Fix sensor verification logic

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -519,6 +519,11 @@ const applyBtnStyle = () => {};
             return m ? parseFloat(m[1]) : null;
         }
 
+        function resultIsOk(str) {
+            if (!str) return false;
+            return !/(no disponible|error|timeout|sin respuesta)/i.test(str);
+        }
+
         async function refreshTemp() {
             try {
                 const data = await api('/comando/leertemp');
@@ -814,7 +819,7 @@ const applyBtnStyle = () => {};
                 } else {
                     const data = await api(`/comando/${accion}`);
                     toast(`Resultado de ${mod}: ${data.resultado}`);
-                    ok = /OK/i.test(data.resultado || '');
+                    ok = resultIsOk(data.resultado);
                 }
                 updateModuleCard(mod, ok);
             } catch (err) {


### PR DESCRIPTION
## Summary
- improve `verifyModule` success detection
- add helper for sensor results

## Testing
- `npm test` *(fails: Missing script)*
- `node app.mjs` *(fails: spawn udevadm ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6849dc147c008333a71bc6b40fe52200