### PR TITLE
Handle serial port path changes

### DIFF
--- a/PanelDomoticoWeb/util/sendSerial.mjs
+++ b/PanelDomoticoWeb/util/sendSerial.mjs
@@ -38,6 +38,21 @@ await checkArduino();
 export default async function sendSerial(comando) {
     const cfg = await readConfig();
     const portPath = cfg.serialPort || 'COM5';
+    if (port && port.path !== portPath) {
+        await new Promise(res => {
+            if (port.isOpen) {
+                port.close(() => res());
+            } else {
+                res();
+            }
+        });
+        port = new SerialPort(portPath, { baudRate: 9600, autoOpen: false });
+        parser = port.pipe(new ReadlineParser({ delimiter: '\r\n' }));
+        port.on('error', err => {
+            console.error('Error en el puerto serial:', err.message);
+        });
+        await checkArduino();
+    }
     if (!arduinoAvailable) {
         await checkArduino();
         if (!arduinoAvailable) {


### PR DESCRIPTION
## Summary
- detect runtime serial port path changes in `sendSerial()`
- recreate `SerialPort` instance when the configured port path changes

## Testing
- `npx eslint -c PanelDomoticoWeb/eslint.config.js PanelDomoticoWeb/util/sendSerial.mjs` *(fails: "module is not defined" error)*

------
https://chatgpt.com/codex/tasks/task_e_6849e02553bc8333995c517f5fd185cd