### PR TITLE
Fix buzzer verification behavior

### DIFF
--- a/PanelDomoticoWeb/comandos/buzzer_status.mjs
+++ b/PanelDomoticoWeb/comandos/buzzer_status.mjs
@@ -1,0 +1,5 @@
+import sendSerial from '../util/sendSerial.mjs';
+
+export default async function () {
+    return await sendSerial('buzzer_status');
+}

--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -620,7 +620,7 @@ const applyBtnStyle = () => {};
             'PIR Sensor': 'pir',
             'RFID Reader': 'rfid',
             'Ultrasonido': 'distancia',
-            'Buzzer': 'alarm'
+            'Buzzer': 'buzzer_status'
         };
 
         let moduleInterval;

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The UI includes:
 - A responsive dashboard with a sidebar menu
 - Theme toggle (light/dark)
 - Module verification with loading feedback
+- Silent buzzer status checks (the buzzer only sounds on alarms or when
+  using the "Probar" testing button)
 - Temperature chart with hover tooltips
 
 

--- a/arduino/EduSecMega/EduSecMega.ino
+++ b/arduino/EduSecMega/EduSecMega.ino
@@ -228,6 +228,9 @@ void loop() {
     }
     Serial.println(listado);
   }
+  else if (strcmp(cmd, "buzzer_status") == 0) {
+    Serial.println(F("Buzzer listo"));
+  }
   else if (strcmp(cmd, "alarm") == 0) {
     sonarAlarma();
     Serial.println(F("Alarma sonó"));

--- a/arduino/EduSecMega/EduSecMega_R2.ino
+++ b/arduino/EduSecMega/EduSecMega_R2.ino
@@ -201,6 +201,9 @@ void loop(){
     }
     Serial.println(listado);
   }
+  else if(strcmp(cmd,"buzzer_status")==0){
+    Serial.println(F("Buzzer listo"));
+  }
   else if(strcmp(cmd,"alarm")==0){
     alarm();
     Serial.println(F("Alarma sonó"));


### PR DESCRIPTION
## Summary
- add a dedicated command `buzzer_status` for silent buzzer checks
- use the new command when verifying modules
- describe quiet buzzer checks in the README
- update Arduino sketches to respond to the `buzzer_status` command

## Testing
- `node --check app.mjs`
- `node --check PanelDomoticoWeb/public/panel.js`
- `node --check PanelDomoticoWeb/comandos/buzzer_status.mjs`


------
https://chatgpt.com/codex/tasks/task_e_6849eccedd68833397a790e345d37e0a