### PR TITLE
Extend Estatus with missing modules

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -281,6 +281,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${moduleCard('RFID Reader')}
                 ${moduleCard('Ultrasonido')}
                 ${moduleCard('Buzzer')}
+                ${moduleCard('Huella Digital')}
+                ${moduleCard('Sensor Temp')}
+                ${moduleCard('RGB LED')}
               </div>
             </section>`,
 
@@ -605,7 +608,10 @@ const applyBtnStyle = () => {};
             'PIR Sensor': 'pir',
             'RFID Reader': 'rfid',
             'Ultrasonido': 'distancia',
-            'Buzzer': 'buzzer_status'
+            'Buzzer': 'buzzer_status',
+            'Huella Digital': 'huella',
+            'Sensor Temp': 'leertemp',
+            'RGB LED': 'rgb_off'
         };
 
         let moduleInterval;


### PR DESCRIPTION
## Summary
- show additional module status cards for the fingerprint reader, temperature sensor and RGB LED
- add commands for these modules so `startModuleMonitoring` checks them as well

## Testing
- `npm test` *(fails: Missing script)*
- `(cd PanelDomoticoWeb && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849ef94c4048333935e4083cddee26c