### PR TITLE
Add fingerprint management routes

### DIFF
--- a/PanelDomoticoWeb/comandos/borrar.mjs
+++ b/PanelDomoticoWeb/comandos/borrar.mjs
@@ -1,7 +1,5 @@
 import sendSerial from '../util/sendSerial.mjs';
 
-export default async function () {
-    // Aquí como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
-    const id = 5;
+export default async function borrar(id) {
     return await sendSerial(`borrar ${id}`);
 }

--- a/PanelDomoticoWeb/comandos/enrolar.mjs
+++ b/PanelDomoticoWeb/comandos/enrolar.mjs
@@ -1,7 +1,5 @@
 import sendSerial from '../util/sendSerial.mjs';
 
-export default async function () {
-    // Aquí como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
-    const id = 5;
+export default async function enrolar(id) {
     return await sendSerial(`enrolar ${id}`);
 }


### PR DESCRIPTION
## Summary
- export enrolar/borrar commands that accept an id
- load those commands in `app.mjs` and expose new `/huellas/:id` POST and DELETE endpoints

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849f2e93d74833397fd0234f07e6946