### PR TITLE
Add huella CRUD helpers

### DIFF
--- a/PanelDomoticoWeb/comandos/borrar.mjs
+++ b/PanelDomoticoWeb/comandos/borrar.mjs
@@ -1,7 +1,8 @@
 import sendSerial from '../util/sendSerial.mjs';
 
-export default async function () {
-    // Aquí como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
-    const id = 5;
+export default async function (id) {
+    if (!id && id !== 0) {
+        throw new Error('ID de huella requerido');
+    }
     return await sendSerial(`borrar ${id}`);
 }

--- a/PanelDomoticoWeb/comandos/enrolar.mjs
+++ b/PanelDomoticoWeb/comandos/enrolar.mjs
@@ -1,7 +1,8 @@
 import sendSerial from '../util/sendSerial.mjs';
 
-export default async function () {
-    // Aquí como ejemplo usa ID = 5; en el futuro enviaremos el ID desde el frontend.
-    const id = 5;
+export default async function (id) {
+    if (!id && id !== 0) {
+        throw new Error('ID de huella requerido');
+    }
     return await sendSerial(`enrolar ${id}`);
 }

--- a/PanelDomoticoWeb/db.js
+++ b/PanelDomoticoWeb/db.js
@@ -92,3 +92,45 @@ export async function initDb() {
 
     return db;
 }
+
+// ----- CRUD helpers for huellas -----
+
+export async function addHuella({ usuario_id, huella_id }) {
+    const db = await getDb();
+    return db.run(
+        `INSERT INTO huellas (usuario_id, huella_id) VALUES (?, ?)`,
+        [usuario_id, huella_id]
+    );
+}
+
+export async function getHuellas() {
+    const db = await getDb();
+    return db.all(`SELECT * FROM huellas`);
+}
+
+export async function getHuellaById(id) {
+    const db = await getDb();
+    return db.get(`SELECT * FROM huellas WHERE id = ?`, [id]);
+}
+
+export async function updateHuella(id, { usuario_id, huella_id }) {
+    const updates = [];
+    const params = [];
+    if (typeof usuario_id !== 'undefined') {
+        updates.push('usuario_id = ?');
+        params.push(usuario_id);
+    }
+    if (typeof huella_id !== 'undefined') {
+        updates.push('huella_id = ?');
+        params.push(huella_id);
+    }
+    if (!updates.length) return;
+    params.push(id);
+    const db = await getDb();
+    return db.run(`UPDATE huellas SET ${updates.join(', ')} WHERE id = ?`, params);
+}
+
+export async function deleteHuella(id) {
+    const db = await getDb();
+    return db.run(`DELETE FROM huellas WHERE id = ?`, [id]);
+}


### PR DESCRIPTION
## Summary
- expose helper functions for CRUD on the `huellas` table
- handle enroll/delete logic through `addHuella` and `deleteHuella`
- pass fingerprint id to commands
- update `enrolar` and `borrar` command modules to accept an id

## Testing
- `node --check PanelDomoticoWeb/app.mjs`
- `node --check PanelDomoticoWeb/comandos/enrolar.mjs`
- `node --check PanelDomoticoWeb/comandos/borrar.mjs`
- `node --check PanelDomoticoWeb/db.js`
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6849f2ea25e88333840ec124203059a9