### PR TITLE
Fix enrolar command export

### DIFF
--- a/PanelDomoticoWeb/comandos/enrolar.mjs
+++ b/PanelDomoticoWeb/comandos/enrolar.mjs
@@ -1,4 +1,6 @@
 import sendSerial from '../util/sendSerial.mjs';
 
+export default async function (id) {
+    if (!id && id !== 0) throw new Error('ID de huella requerido');
     return await sendSerial(`enrolar ${id}`);
 }


### PR DESCRIPTION
## Summary
- fix the `enrolar` command so it exports a function

## Testing
- `npm install`
- `node - <<'NODE'
import { pathToFileURL } from 'url';
import path from 'path';
const modulePath = pathToFileURL(path.join('comandos', 'enrolar.mjs')).href;
import(modulePath).then(m => {
  console.log('loaded', typeof m.default);
}).catch(err => {
  console.error('error', err);
});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6849f884b4048333b329707a9e2d7fee