### PR TITLE
Fix import of DB helper functions

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import fs from 'fs/promises';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
-import { getDb, initDb } from './db.js';
+import { getDb, initDb, addHuella, deleteHuella } from './db.js';
 import sendSerial, { isArduinoAvailable } from './util/sendSerial.mjs';
 import { readConfig, writeConfig } from './util/config.mjs';
 import enrolarCmd from './comandos/enrolar.mjs';


### PR DESCRIPTION
## Summary
- load `addHuella` and `deleteHuella` from `db.js` in `app.mjs`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6849f9a08b008333b44f02ebd8784354