### PR TITLE
Fix duplicate menu entry

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -426,7 +426,6 @@ document.addEventListener("DOMContentLoaded", () => {
             ["acceso", "lock", "Acceso principal"],
             ["monitoreo", "shield", "Monitoreo"],
             ["estatus", "activity", "Estatus"],
-            ["monitoreo", "eye", "Monitoreo"],
             ["config", "settings", "Configuración"],
             ["cuentas", "users", "Cuentas"],
             ["acerca", "info", "Acerca"]


### PR DESCRIPTION
## Summary
- remove duplicate "monitoreo" menu definition

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a1e7732fc8333a4f93a861cdeccb9