### PR TITLE
Add CSV export for security events

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -341,7 +341,10 @@ document.addEventListener("DOMContentLoaded", () => {
                   </div>
                 </div>
                 <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-6 space-y-4">
-                  <h4 class="font-bold">Registro de Eventos de Seguridad</h4>
+                  <div class="flex justify-between items-center">
+                    <h4 class="font-bold">Registro de Eventos de Seguridad</h4>
+                    ${currentUser && currentUser.role === 'root' ? '<button onclick="exportSecurityCSV()" class="px-3 py-1 bg-[#1683d8] hover:bg-[#126bb3] text-white rounded text-sm">Exportar CSV</button>' : ''}
+                  </div>
                   <div id="securityLog"></div>
                 </div>
               </div>
@@ -660,6 +663,25 @@ const applyBtnStyle = () => {};
             } catch (err) {
                 toast(err.message);
             }
+        }
+
+        function exportSecurityCSV() {
+            if (!securityLogs.length) return;
+            const header = 'hora,evento\n';
+            const csv = header + securityLogs.map(l => {
+                const [h, ev] = l.split(' - ');
+                const e = (ev || '').replace(/"/g, '""');
+                return `"${h}","${e}"`;
+            }).join('\n');
+            const blob = new Blob([csv], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const aEl = document.createElement('a');
+            aEl.href = url;
+            aEl.download = 'security_log.csv';
+            document.body.appendChild(aEl);
+            aEl.click();
+            document.body.removeChild(aEl);
+            URL.revokeObjectURL(url);
         }
 
         function toggleRfidAdmin() {
@@ -1257,6 +1279,7 @@ const applyBtnStyle = () => {};
         window.toggleRfidAdmin = toggleRfidAdmin;
         window.updateAccessTable = updateAccessTable;
         window.exportAccessCSV = exportAccessCSV;
+        window.exportSecurityCSV = exportSecurityCSV;
         window.verifyModule = verifyModule;
         window.showEnrollModal = showEnrollModal;
         window.showRfidModal = showRfidModal;


### PR DESCRIPTION
## Summary
- add export button to security log card
- implement `exportSecurityCSV` helper for downloading the current log

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a02d45f888333be2b608b1ca5339f