### PR TITLE
Stream serial prompts via SSE

### DIFF
--- a/PanelDomoticoWeb/util/sendSerial.mjs
+++ b/PanelDomoticoWeb/util/sendSerial.mjs
@@ -1,10 +1,14 @@
 // util/sendSerial.mjs
 import { SerialPort } from 'serialport';
 import { ReadlineParser } from '@serialport/parser-readline';
+import { EventEmitter } from 'events';
 import { readConfig } from './config.mjs';
+
+export const serialEmitter = new EventEmitter();
 
 let port;
 let parser;
+let parserHooked = false;
 let arduinoAvailable = false;
 
 /**
@@ -28,6 +32,18 @@ export function isArduinoAvailable() {
 
 await checkArduino();
 
+function createPort(portPath) {
+    port = new SerialPort({ path: portPath, baudRate: 9600, autoOpen: false });
+    parser = port.pipe(new ReadlineParser({ delimiter: '\r\n' }));
+    port.on('error', err => {
+        console.error('Error en el puerto serial:', err.message);
+    });
+    if (!parserHooked) {
+        parser.on('data', d => serialEmitter.emit('message', d));
+        parserHooked = true;
+    }
+}
+
 /**
  * Inicializa el puerto serie (si no está inicializado) y retorna una promesa
  * que resuelve con la respuesta del Arduino.
@@ -46,12 +62,7 @@ export default async function sendSerial(comando) {
                 res();
             }
         });
-        // SerialPort v12 expects an options object with the path
-        port = new SerialPort({ path: portPath, baudRate: 9600, autoOpen: false });
-        parser = port.pipe(new ReadlineParser({ delimiter: '\r\n' }));
-        port.on('error', err => {
-            console.error('Error en el puerto serial:', err.message);
-        });
+        createPort(portPath);
         await checkArduino();
     }
     if (!arduinoAvailable) {
@@ -63,12 +74,7 @@ export default async function sendSerial(comando) {
     return new Promise((resolve) => {
         // Inicializar puerto y parser si es necesario
         if (!port) {
-            // Initialize using the object-based API
-            port = new SerialPort({ path: portPath, baudRate: 9600, autoOpen: false });
-            parser = port.pipe(new ReadlineParser({ delimiter: '\r\n' }));
-            port.on('error', err => {
-                console.error('Error en el puerto serial:', err.message);
-            });
+            createPort(portPath);
         }
 
         const writeCmd = () => {
@@ -106,5 +112,69 @@ export default async function sendSerial(comando) {
             clearTimeout(timeoutId);
             onData(data);
         });
+    });
+}
+
+export async function sendSerialStream(comando, endRegex = /(enrolada|error)/i, timeout = 30000) {
+    const cfg = await readConfig();
+    const portPath = cfg.serialPort || 'COM5';
+    if (port && port.path !== portPath) {
+        await new Promise(res => {
+            if (port.isOpen) {
+                port.close(() => res());
+            } else {
+                res();
+            }
+        });
+        createPort(portPath);
+        await checkArduino();
+    }
+    if (!arduinoAvailable) {
+        await checkArduino();
+        if (!arduinoAvailable) {
+            return `Arduino no disponible (${portPath})`;
+        }
+    }
+    return new Promise(resolve => {
+        if (!port) {
+            createPort(portPath);
+        }
+        const writeCmd = () => {
+            port.write(comando + '\n', err => {
+                if (err) {
+                    arduinoAvailable = false;
+                    cleanup();
+                    return resolve(`Error enviando comando: ${err.message}`);
+                }
+            });
+        };
+        const cleanup = () => {
+            clearTimeout(timer);
+            parser.removeListener('data', onData);
+        };
+        const onData = data => {
+            lastLine = data;
+            if (endRegex.test(data)) {
+                cleanup();
+                resolve(data);
+            }
+        };
+        if (!port.isOpen) {
+            port.open(err => {
+                if (err) {
+                    arduinoAvailable = false;
+                    return resolve(`Error abriendo puerto: ${err.message}`);
+                }
+                writeCmd();
+            });
+        } else {
+            writeCmd();
+        }
+        let lastLine = '';
+        parser.on('data', onData);
+        const timer = setTimeout(() => {
+            cleanup();
+            resolve(lastLine || 'Timeout: sin respuesta del Arduino.');
+        }, timeout);
     });
 }


### PR DESCRIPTION
## Summary
- broadcast serial output through an EventEmitter
- expose `/serial-events` SSE endpoint
- stream fingerprint enrollment messages
- show enrollment progress in a modal on the client

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a21f130948333b5ceec2e2c37d3c7