### PR TITLE
Add settings storage and API

### DIFF
--- a/PanelDomoticoWeb/db.js
+++ b/PanelDomoticoWeb/db.js
@@ -79,6 +79,14 @@ export async function initDb() {
     )
   `);
 
+    // Tabla de ajustes generales
+    await db.exec(`
+    CREATE TABLE IF NOT EXISTS ajustes (
+      clave TEXT PRIMARY KEY,
+      valor TEXT
+    )
+  `);
+
     // Revisar si existe al menos un usuario root por defecto; si no, lo creamos
     const row = await db.get(`SELECT COUNT(*) AS count FROM usuarios`);
     if (row.count === 0) {
@@ -171,4 +179,21 @@ export async function getRfidCards() {
 export async function deleteRfidCard(uid) {
     const db = await getDb();
     return db.run('DELETE FROM rfid_cards WHERE uid = ?', [uid]);
+}
+
+// ----- Ajustes generales -----
+
+export async function getSetting(clave) {
+    const db = await getDb();
+    const row = await db.get('SELECT valor FROM ajustes WHERE clave = ?', [clave]);
+    return row ? row.valor : null;
+}
+
+export async function setSetting(clave, valor) {
+    const db = await getDb();
+    return db.run(
+        `INSERT INTO ajustes (clave, valor) VALUES (?, ?)
+         ON CONFLICT(clave) DO UPDATE SET valor = excluded.valor`,
+        [clave, valor]
+    );
 }

--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -467,7 +467,10 @@ document.addEventListener("DOMContentLoaded", () => {
             if (id === 'acceso') updateAccessTable(new Date().toISOString().substring(0, 10));
             if (id === 'estatus') startModuleMonitoring();
             if (id === 'monitoreo') startSecurityMonitoring();
-            if (id === 'config') loadSerialPort();
+            if (id === 'config') {
+                loadSerialPort();
+                applySettingsUI();
+            }
         }
 
 
@@ -1062,6 +1065,7 @@ const applyBtnStyle = () => {};
         let lastDoorOpen = null;
         const securityLogs = [];
         let simulatedMode = true;
+        let currentSettings = {};
 
         const api = async (url, opts = {}) => {
             opts.headers = opts.headers || {};
@@ -1085,6 +1089,11 @@ const applyBtnStyle = () => {};
                 jwtToken = data.token;
                 currentUser = { username: data.username, role: data.role };
                 lblUser.textContent = data.username;
+                if (data.role === 'root') {
+                    try {
+                        currentSettings = await api('/settings');
+                    } catch {}
+                }
                 loadingOverlay.classList.remove('hidden');
                 setTimeout(() => {
                     loginCard.classList.add('hidden');
@@ -1124,6 +1133,15 @@ const applyBtnStyle = () => {};
             } catch {
                 toast('Error cargando configuración');
             }
+        }
+
+        function applySettingsUI() {
+            const acc = document.getElementById('chkNotifAcc');
+            const sec = document.getElementById('chkNotifSec');
+            const sys = document.getElementById('chkNotifSys');
+            if (acc) acc.checked = /^(true|1)$/.test(currentSettings.notifAcc);
+            if (sec) sec.checked = /^(true|1)$/.test(currentSettings.notifSec);
+            if (sys) sys.checked = /^(true|1)$/.test(currentSettings.notifSys);
         }
 
         function renderUsers(list) {
@@ -1261,6 +1279,23 @@ const applyBtnStyle = () => {};
                         toast(err.message);
                         return;
                     }
+                }
+
+                const prefs = {
+                    notifAcc: document.getElementById('chkNotifAcc').checked,
+                    notifSec: document.getElementById('chkNotifSec').checked,
+                    notifSys: document.getElementById('chkNotifSys').checked
+                };
+                try {
+                    await api('/settings', {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(prefs)
+                    });
+                    Object.assign(currentSettings, prefs);
+                } catch (err) {
+                    toast(err.message);
+                    return;
                 }
                 toast('Preferencias guardadas');
             } else if (e.target.closest('#backupBtn')) {


### PR DESCRIPTION
## Summary
- create `ajustes` table in SQLite database for storing key/value pairs
- expose `getSetting` and `setSetting` helpers
- implement `/settings` API endpoints
- load and update notification preferences from the frontend

## Testing
- `node --check PanelDomoticoWeb/app.mjs`
- `node --check PanelDomoticoWeb/db.js`

------
https://chatgpt.com/codex/tasks/task_e_684a6534dd8483339d049805906539e4