### PR TITLE
Improve admin panels

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -173,11 +173,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Tabla de huellas
         function fingerTable() {
+            const actionsHead = currentUser && currentUser.role === 'root'
+                ? '<th class="px-3 py-2 text-left">Acciones</th>' : '';
             return `
             <div class="overflow-x-auto">
               <table class="min-w-full text-sm divide-y divide-slate-200 dark:divide-slate-700">
                 <thead class="bg-slate-100 dark:bg-slate-700">
-                  <tr><th class="px-3 py-2 text-left">ID Huella</th><th class="px-3 py-2 text-left">Nombre Completo</th><th class="px-3 py-2 text-left">Acciones</th></tr>
+                  <tr><th class="px-3 py-2 text-left">ID Huella</th><th class="px-3 py-2 text-left">Nombre Completo</th>${actionsHead}</tr>
                 </thead>
                 <tbody id="fingerTBody" class="divide-y divide-slate-200 dark:divide-slate-700"></tbody>
               </table>
@@ -186,11 +188,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Tabla de tarjetas RFID
         function rfidTable() {
+            const actionsHead = currentUser && currentUser.role === 'root'
+                ? '<th class="px-3 py-2 text-left">Acciones</th>' : '';
             return `
             <div class="overflow-x-auto">
               <table class="min-w-full text-sm divide-y divide-slate-200 dark:divide-slate-700">
                 <thead class="bg-slate-100 dark:bg-slate-700">
-                  <tr><th class="px-3 py-2 text-left">UID</th><th class="px-3 py-2 text-left">Usuario</th><th class="px-3 py-2 text-left">Acciones</th></tr>
+                  <tr><th class="px-3 py-2 text-left">UID</th><th class="px-3 py-2 text-left">Usuario</th>${actionsHead}</tr>
                 </thead>
                 <tbody id="rfidTBody" class="divide-y divide-slate-200 dark:divide-slate-700"></tbody>
               </table>
@@ -262,16 +266,18 @@ document.addEventListener("DOMContentLoaded", () => {
                   <div id="accessContainer"></div>
                 </div>
               </div>
-              <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-6 space-y-4">
-                <div class="flex justify-between items-center">
-                  <h4 class="font-bold">Huella Digital</h4>
+              <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-4 space-y-3 relative">
+                <div class="flex items-start justify-between">
+                  <div>
+                    <h4 class="font-bold">Huella Digital</h4>
+                    <p class="text-sm text-slate-500 dark:text-slate-400" id="fingerSensorState">Sensor huella: <span class="font-semibold">OK</span></p>
+                  </div>
                   <button id="btnMoreAccion" class="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700"><i data-feather="more-horizontal"></i></button>
                 </div>
-                <p class="text-sm" id="fingerSensorState">Sensor huella: <span class="font-medium">OK</span></p>
-                <button onclick="toggleFingerAdmin()" class="btn w-full text-base">Administrar Huellas</button>
-                <div id="fingerAdmin" class="hidden space-y-4">
+                <button onclick="toggleFingerAdmin()" class="btn w-full">Administrar Huellas</button>
+                <div id="fingerAdmin" class="collapsible space-y-3">
                   ${fingerTable()}
-                  <button id="addHuellaBtn" class="btn w-full">Agregar Nueva Huella</button>
+                  ${currentUser && currentUser.role === 'root' ? `<div class="admin-footer"><button id="addHuellaBtn" class="btn-outline w-full">Agregar Nueva Huella</button></div>` : ''}
                 </div>
                 <!-- Menú oculto de acciones: Abrir / Cerrar -->
                 <div id="menuAcciones" class="hidden absolute bg-white dark:bg-slate-800 shadow rounded mt-2 right-6 w-40 divide-y divide-slate-200 dark:divide-slate-700">
@@ -338,16 +344,14 @@ document.addEventListener("DOMContentLoaded", () => {
                   </div>
                   <div id="securityLog"></div>
                 </div>
-                ${currentUser && currentUser.role === 'root' ? `
-                <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-6 space-y-4">
+                <div class="bg-white dark:bg-slate-800 rounded-lg shadow p-4 space-y-3 md:col-span-2">
                   <h4 class="font-bold">Tarjetas RFID</h4>
-                  <button onclick="toggleRfidAdmin()" class="btn w-full text-base">Administrar Tarjetas</button>
-                  <div id="rfidAdmin" class="hidden space-y-4">
+                  <button onclick="toggleRfidAdmin()" class="btn w-full">Administrar Tarjetas</button>
+                  <div id="rfidAdmin" class="collapsible space-y-3">
                     ${rfidTable()}
-                    <button id="addRfidBtn" class="btn w-full">Agregar Nueva Tarjeta</button>
+                    ${currentUser && currentUser.role === 'root' ? `<div class="admin-footer"><button id="addRfidBtn" class="btn-outline w-full">Agregar Nueva Tarjeta</button></div>` : ''}
                   </div>
                 </div>
-                ` : ''}
               </div>
             </section>`,
 
@@ -588,10 +592,14 @@ const applyBtnStyle = () => {};
         function toggleFingerAdmin() {
             const d = document.getElementById('fingerAdmin');
             if (!d) return;
-            const wasHidden = d.classList.contains('hidden');
-            d.classList.toggle('hidden');
-            if (wasHidden && !d.classList.contains('hidden')) {
+            const opening = !d.classList.contains('open');
+            if (opening) {
+                d.classList.add('open');
+                d.style.maxHeight = d.scrollHeight + 'px';
                 loadHuellas();
+            } else {
+                d.style.maxHeight = '0px';
+                d.classList.remove('open');
             }
         }
 
@@ -717,10 +725,14 @@ const applyBtnStyle = () => {};
         function toggleRfidAdmin() {
             const d = document.getElementById('rfidAdmin');
             if (!d) return;
-            const wasHidden = d.classList.contains('hidden');
-            d.classList.toggle('hidden');
-            if (wasHidden && !d.classList.contains('hidden')) {
+            const opening = !d.classList.contains('open');
+            if (opening) {
+                d.classList.add('open');
+                d.style.maxHeight = d.scrollHeight + 'px';
                 loadRfidCards();
+            } else {
+                d.style.maxHeight = '0px';
+                d.classList.remove('open');
             }
         }
 
@@ -793,7 +805,11 @@ const applyBtnStyle = () => {};
             list.forEach(item => {
                 const tr = document.createElement('tr');
                 const user = userMap[item.usuario_id] || item.usuario_id;
-                tr.innerHTML = `<td class="px-3 py-1">${item.uid}</td><td class="px-3 py-1">${user}</td><td class="px-3 py-1"><button class="delRfid btn btn-sm btn-danger" data-uid="${item.uid}">Eliminar</button></td>`;
+                let cells = `<td class="px-3 py-1">${item.uid}</td><td class="px-3 py-1">${user}</td>`;
+                if (currentUser && currentUser.role === 'root') {
+                    cells += `<td class="px-3 py-1"><button class="delRfid btn btn-sm btn-danger" data-uid="${item.uid}">Eliminar</button></td>`;
+                }
+                tr.innerHTML = cells;
                 tbody.appendChild(tr);
             });
         }
@@ -1173,7 +1189,11 @@ const applyBtnStyle = () => {};
             list.forEach(item => {
                 const tr = document.createElement('tr');
                 const full = `${item.nombre || ''} ${item.apellido_pat || ''} ${item.apellido_mat || ''}`.trim();
-                tr.innerHTML = `<td class="px-3 py-1">${item.huella_id}</td><td class="px-3 py-1">${full}</td><td class="px-3 py-1"><button class="delFinger btn btn-sm btn-danger" data-id="${item.huella_id}">Eliminar</button></td>`;
+                let cells = `<td class="px-3 py-1">${item.huella_id}</td><td class="px-3 py-1">${full}</td>`;
+                if (currentUser && currentUser.role === 'root') {
+                    cells += `<td class="px-3 py-1"><button class="delFinger btn btn-sm btn-danger" data-id="${item.huella_id}">Eliminar</button></td>`;
+                }
+                tr.innerHTML = cells;
                 tbody.appendChild(tr);
             });
         }

--- a/PanelDomoticoWeb/public/style.css
+++ b/PanelDomoticoWeb/public/style.css
@@ -115,6 +115,21 @@ body {
     font-size: 0.875rem;
 }
 
+/* outline button variant */
+.btn-outline {
+    background-color: transparent;
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+}
+.btn-outline:hover {
+    background-color: var(--primary-color);
+    color: var(--accent-text);
+    transform: translateY(-1px);
+}
+.btn-outline:active {
+    transform: scale(0.97);
+}
+
 .btn-danger {
     background-image: none;
     background-color: #dc2626;
@@ -434,6 +449,26 @@ body {
     background-color: #374151;
     opacity: 0.7;
     pointer-events: none;
+}
+
+/* simple collapsible container */
+.collapsible {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height .3s ease;
+}
+.collapsible.open {
+    max-height: 999px;
+}
+
+/* spacing and divider for tables inside admin panels */
+.admin-footer {
+    border-top: 1px solid rgba(0,0,0,0.1);
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+}
+.dark .admin-footer {
+    border-color: rgba(255,255,255,0.1);
 }
 
 .details-card > div {


### PR DESCRIPTION
## Summary
- allow admins to view RFID card list
- span RFID card across two columns for better layout
- separate add buttons with new outline style
- hide add/delete actions for non-root users

## Testing
- `npx eslint public/panel.js` *(fails: module is not defined)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a648fb84083338e0d7d74c68c1046