### PR TITLE
Fix monitoring start on login

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -909,7 +909,7 @@ const applyBtnStyle = () => {};
            setCheckingStatuses();
            updateModulesSummary();
            checkAllModules();
-           moduleInterval = setInterval(checkAllModules, 60000);
+           moduleInterval = setInterval(checkAllModules, 10000);
        }
 
         function updateSystemStateUI() {
@@ -1190,6 +1190,7 @@ const applyBtnStyle = () => {};
                     initMenu();
                     document.querySelector('#menu button').click();
                     startPolling();
+                    startModuleMonitoring();
                     initSessionTimeout();
                     checkAllModules().then(updateModulesSummary);
                     api('/status/arduino').then(s => {


### PR DESCRIPTION
## Summary
- begin monitoring modules immediately on login
- shorten module polling interval from 60s to 10s

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ae64e65748333885ede7c39e06f67