### PR TITLE
Allow closing Arduino alert overlay anytime

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -21,16 +21,17 @@ document.addEventListener("DOMContentLoaded", () => {
     if (arduinoAlertClose) {
         arduinoAlertClose.onclick = async () => {
             const s = await api('/status/arduino').catch(() => ({ available: false }));
-            updateArduinoAlert(s.available);
-            if (s.available) return;
-            showArduinoReminder();
+            arduinoConnected = !!s.available;
+            arduinoAlert.classList.add('hidden');
+            if (!s.available) showArduinoReminder();
         };
     }
 
     document.addEventListener('keydown', async e => {
         if (e.key === 'Escape' && !arduinoAlert.classList.contains('hidden')) {
             const s = await api('/status/arduino').catch(() => ({ available: false }));
-            updateArduinoAlert(s.available);
+            arduinoConnected = !!s.available;
+            arduinoAlert.classList.add('hidden');
             if (!s.available) showArduinoReminder();
         }
     });


### PR DESCRIPTION
## Summary
- let `arduinoAlertClose` hide the overlay even if the board is unavailable
- do the same in the Escape key listener

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b12b7b29c833387fdd2763d6980dc