### PR TITLE
Enable continuous RFID scanning

### DIFF
--- a/arduino/EduSecMega/README.md
+++ b/arduino/EduSecMega/README.md
@@ -13,8 +13,8 @@ The latest revision of this firmware is `EduSecMega_R2.ino`.
 | PIR sensor                          | 2   |
 | Ultrasonic TRIG                     | 8   |
 | Ultrasonic ECHO                     | 5   |
-| RFID SDA                            | 10  |
-| RFID RST                            | 9   |
+| RFID SDA                            | 30  |
+| RFID RST                            | 31  |
 | RFID MOSI                           | 51  |
 | RFID MISO                           | 50  |
 | RFID SCK                            | 52  |
@@ -53,11 +53,13 @@ missing, verify the following:
 1. **Power connections** – The MFRC522 module must be powered from 3.3 V. The
    fingerprint sensor uses the 5 V pin.
 2. **Signal wiring** – Connect the RC522's MOSI/MISO/SCK lines to pins
-   51/50/52 on the Mega, its SDA line to pin 10 and the RST line to pin 9.
+   51/50/52 on the Mega, its SDA line to pin 30 and the RST line to pin 31.
    The fingerprint sensor's TX pin goes to RX1 (pin 19) and its RX pin to
    TX1 (pin 18).
-3. **Serial commands** – Reading either module requires sending the commands
-   `rfid` or `huella` (or `enrolar <id>`/`borrar <id>`). You can do this from
-   the web interface or a serial terminal. The firmware will report
+3. **Serial commands** – The fingerprint sensor still requires the commands
+   `huella`, `enrolar <id>` or `borrar <id>`.
+   Since revision R2 the RFID reader scans automatically and prints
+   `UID:` messages whenever a card is detected, though the `rfid` command
+   remains available for manual checks. The firmware reports
    "RFID listo"/"Sensor de huella listo" on startup when each peripheral is
    detected.

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -17,6 +17,11 @@ To build and upload a sketch using the Arduino IDE:
    - MFRC522
 4. Connect the board and upload.
 
+Revision R2 changes the MFRC522 wiring:
+`SDA` is now connected to pin **30** and `RST` to pin **31**.
+The firmware continuously scans for RFID cards and prints `UID:` messages
+on detection. The `rfid` command is still available for manual tests.
+
 The Node.js backend communicates with the board over a serial port at 9600
 baud. Commands must be terminated with a newline character and the firmware
 responds with a single line of text.


### PR DESCRIPTION
## Summary
- rewire MFRC522 pins and keep scanning inside main loop
- handle unsolicited UID messages in the backend to disarm the system
- drop RFID polling from the web UI and listen to serial events
- document new RFID wiring and continuous scanning

## Testing
- `npm install --silent`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684b40b191788333aa38e5473c39c63f