### PR TITLE
Add fingerprint access flow

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -225,7 +225,7 @@ app.get('/comando/:accion', authenticateToken, async (req, res) => {
     }
     try {
         const id = req.query.id ? parseInt(req.query.id, 10) : undefined;
-        const resultado = await fn(id);
+        let resultado = await fn(id);
         await db.run(
             `INSERT INTO logs (usuario_id, accion, detalle)
          VALUES (?, ?, ?)`,
@@ -235,6 +235,11 @@ app.get('/comando/:accion', authenticateToken, async (req, res) => {
             await addHuella({ usuario_id: req.user.id, huella_id: id });
         } else if (accion === 'borrar' && typeof id !== 'undefined') {
             await deleteHuella(id);
+        } else if (accion === 'huella' && /válida/i.test(resultado)) {
+            sendSerial('abrir').catch(() => {});
+            setTimeout(() => {
+                sendSerial('cerrar').catch(() => {});
+            }, 5000);
         }
         return res.json({ accion, resultado });
     } catch (err) {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The `arduino/` directory contains the sketches that run on the microcontroller.
 respective `README.md` files for pin mapping and library requirements.
 Currently `arduino/EduSecMega/EduSecMega_R2.ino` is the recommended firmware and the version deployed on the demo panel. The previous `EduSecMega.ino` file is kept for reference.
 
+### Fingerprint Access
+
+The `huella` command triggers a fingerprint check on the Arduino. If a valid finger is detected the relay is opened for around five seconds and a message is printed to the serial port. The backend waits for this response, logs it and also issues `abrir` followed by `cerrar` as a backup.
+
 ### Assets Notice
 The logo file `logo_edusec.png` is not included in this repository.
 After cloning the project, manually copy it into:

--- a/arduino/EduSecMega/EduSecMega_R2.ino
+++ b/arduino/EduSecMega/EduSecMega_R2.ino
@@ -159,9 +159,17 @@ void loop(){
     }
   }
   else if(hasCmd && strcmp(cmd,"huella")==0){
-    if(!fingerPresent) Serial.println(F("Sensor de huella no disponible"));
-    else if(verifyFinger()) Serial.println(F("Huella válida"));
-    else Serial.println(F("Huella no válida"));
+    if(!fingerPresent){
+      Serial.println(F("Sensor de huella no disponible"));
+    } else if(verifyFinger()){
+      Serial.println(F("Huella válida - abriendo relé"));
+      digitalWrite(RELAY_PIN, LOW);
+      delay(5000);
+      digitalWrite(RELAY_PIN, HIGH);
+      Serial.println(F("Relé cerrado"));
+    } else {
+      Serial.println(F("Huella no válida"));
+    }
   }
   else if(hasCmd && strcmp(cmd,"distancia")==0){
     long d = readDistance();


### PR DESCRIPTION
## Summary
- open and close relay on valid fingerprint
- trigger door open/close from backend when `/comando/huella` succeeds
- show fingerprint messages in the web UI security log
- document new fingerprint behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c03a41d4483339eb2c7324087792f