### PR TITLE
Add fingerprint access flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ The `arduino/` directory contains the sketches that run on the microcontroller.
 respective `README.md` files for pin mapping and library requirements.
 Currently `arduino/EduSecMega/EduSecMega_R2.ino` is the recommended firmware and the version deployed on the demo panel. The previous `EduSecMega.ino` file is kept for reference.
 
+### Fingerprint Access
+
+The `huella` command triggers a fingerprint check on the Arduino. If a valid finger is detected the relay opens for about five seconds and a message is printed to the serial port so the backend can log the event. Manual commands from the dashboard still work normally and keep the door open or closed until changed or a fingerprint is read.
+
 ### Assets Notice
 The logo file `logo_edusec.png` is not included in this repository.
 After cloning the project, manually copy it into:

--- a/arduino/EduSecMega/EduSecMega_R2.ino
+++ b/arduino/EduSecMega/EduSecMega_R2.ino
@@ -159,9 +159,17 @@ void loop(){
     }
   }
   else if(hasCmd && strcmp(cmd,"huella")==0){
-    if(!fingerPresent) Serial.println(F("Sensor de huella no disponible"));
-    else if(verifyFinger()) Serial.println(F("Huella válida"));
-    else Serial.println(F("Huella no válida"));
+    if(!fingerPresent){
+      Serial.println(F("Sensor de huella no disponible"));
+    } else if(verifyFinger()){
+      Serial.println(F("Huella válida - abriendo relé"));
+      digitalWrite(RELAY_PIN, LOW);
+      delay(5000);
+      digitalWrite(RELAY_PIN, HIGH);
+      Serial.println(F("Relé cerrado"));
+    } else {
+      Serial.println(F("Huella no válida"));
+    }
   }
   else if(hasCmd && strcmp(cmd,"distancia")==0){
     long d = readDistance();


### PR DESCRIPTION
## Summary
- open relay for 5 seconds directly from the Arduino when a fingerprint matches
- simplify backend command handler without extra open/close
- clarify fingerprint behaviour in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c03a41d4483339eb2c7324087792f