### PR TITLE
Remove door opening on system disarm

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -79,7 +79,6 @@ serialEmitter.on('message', async msg => {
                     `INSERT INTO logs (usuario_id, accion, detalle) VALUES (?, ?, ?)`,
                     [row ? row.usuario_id : null, 'system_state', 'disarmed by rfid']
                 );
-                sendSerial('abrir').catch(() => {});
             } else {
                 systemArmed = true;
                 await writeConfig({ systemArmed });

--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -1159,7 +1159,6 @@ const applyBtnStyle = () => {};
                         systemArmed = !systemArmed;
                         updateSystemStateUI();
                         addSecurityLog(`Sistema ${systemArmed ? 'armado' : 'desarmado'} por RFID`);
-                        if (!systemArmed) cmd('abrir');
                     } catch {}
                 }
             };

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The RGB LED acts as the system status indicator:
 
 When armed, any motion detected by the PIR sensor or a door opening via the distance sensor triggers the alarm. During the alarm the LED flashes red, then returns to solid red once the buzzer stops.
 
-The system can be armed or disarmed either from the dashboard or by presenting a valid RFID card. Swiping a card while disarmed arms the system (LED turns red). Swiping again disarms it and automatically opens the main door.
+The system can be armed or disarmed either from the dashboard or by presenting a valid RFID card. Swiping a card while disarmed arms the system (LED turns red). Swiping again disarms it without opening the door.
 
 ### Fingerprint Access
 


### PR DESCRIPTION
## Summary
- clarify that RFID disarming no longer opens the door
- do not trigger relay when disarming via RFID
- drop client-side automatic open on RFID disarm

## Testing
- `npx eslint PanelDomoticoWeb/app.mjs` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684c239afb848333a11245c06f380017