### PR TITLE
Add demo mode toggle command

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -512,6 +512,11 @@ app.patch('/settings', authenticateToken, async (req, res) => {
             await setSetting(k, String(v));
             if (k === 'sensorDemoMode') {
                 sensorDemoMode = /^(true|1)$/i.test(String(v));
+                try {
+                    await sendSerial(`demo ${sensorDemoMode ? 1 : 0}`);
+                } catch (err) {
+                    console.error('Error enviando modo demo:', err);
+                }
             }
         }
         res.json({ msg: 'ok' });

--- a/arduino/EduSecMega/EduSecMega_R2.ino
+++ b/arduino/EduSecMega/EduSecMega_R2.ino
@@ -25,6 +25,7 @@ DallasTemperature sensors(&oneWire);
 char cmd[64];
 bool fingerPresent = false;
 bool rfidPresent = false;
+bool demoMode = false;
 
 void setRGB(uint8_t r,uint8_t g,uint8_t b){
   analogWrite(LED_R,r);
@@ -250,6 +251,17 @@ void loop(){
       Serial.println(F(" C"));
     }
   }
+  else if(hasCmd && strncmp(cmd,"demo ",5)==0){
+    if(strcmp(cmd+5,"1")==0){
+      demoMode = true;
+      Serial.println(F("Demo mode ON"));
+    } else if(strcmp(cmd+5,"0")==0){
+      demoMode = false;
+      Serial.println(F("Demo mode OFF"));
+    } else {
+      Serial.println(F("comando no reconocido"));
+    }
+  }
   else if(hasCmd){
     Serial.println(F("comando no reconocido"));
   }
@@ -275,6 +287,13 @@ void loop(){
     if(verifyFinger()){
       Serial.print(F("Huella valida ID: "));
       Serial.println(finger.fingerID);
+      digitalWrite(RELAY_PIN, LOW);
+      Serial.println(F("Acceso principal abierto"));
+      delay(5000);
+      digitalWrite(RELAY_PIN, HIGH);
+      Serial.println(F("Acceso principal cerrado"));
+    } else if(demoMode && finger.getImage() == FINGERPRINT_OK){
+      Serial.println(F("Huella valida ID: 0"));
       digitalWrite(RELAY_PIN, LOW);
       Serial.println(F("Acceso principal abierto"));
       delay(5000);

--- a/arduino/EduSecMega/README.md
+++ b/arduino/EduSecMega/README.md
@@ -26,7 +26,9 @@ The latest revision of this firmware is `EduSecMega_R2.ino`.
 
 The serial port runs at 9600 bps and expects newline-terminated commands
 (e.g. `abrir`, `enrolar 5`, `pir`). The sketch responds with a single line
-suitable for the `sendSerial` helper in the Node.js backend.
+suitable for the `sendSerial` helper in the Node.js backend. Revision R2 also
+understands `demo 1` or `demo 0` to enable or disable the firmware's demo mode,
+allowing fingerprints to open the door even if they are not enrolled.
 
 ## Module voltage requirements
 


### PR DESCRIPTION
## Summary
- support demo mode in EduSecMega firmware
- document `demo` command usage
- sync demo mode from Node.js backend when settings change

## Testing
- `node --check PanelDomoticoWeb/app.mjs`

------
https://chatgpt.com/codex/tasks/task_e_684c303f3900833389022e17c4ae797b