### PR TITLE
Initialize Arduino demo mode on startup

### DIFF
--- a/PanelDomoticoWeb/app.mjs
+++ b/PanelDomoticoWeb/app.mjs
@@ -50,6 +50,15 @@ db = await getDb();  // Obtener instancia “promisificada” de la BD
 const cfg = await readConfig();
 let systemArmed = !!cfg.systemArmed;
 let sensorDemoMode = /^(true|1)$/i.test(await getSetting('sensorDemoMode') || 'false');
+try {
+    if (sensorDemoMode) {
+        await sendSerial('demo 1');
+    } else {
+        await sendSerial('demo 0');
+    }
+} catch (err) {
+    console.error('Error inicializando modo demo:', err);
+}
 let lastRfidUid = null;
 let lastRfidTime = 0;
 try {


### PR DESCRIPTION
## Summary
- send `demo` command to Arduino according to saved mode on startup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c79d3248333908e874d7a13a5ab