### PR TITLE
Enable continuous fingerprint scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The `arduino/` directory contains the sketches that run on the microcontroller.
 `arduino/original` stores the standalone prototypes, while
 `arduino/EduSecMega` is the unified sketch for an Arduino Mega. Consult the
 respective `README.md` files for pin mapping and library requirements.
-Currently `arduino/EduSecMega/EduSecMega_R2.ino` is the recommended firmware and the version deployed on the demo panel. The previous `EduSecMega.ino` file is kept for reference.
-The fingerprint reader now scans continuously. When a stored fingerprint is recognized the door relay opens for about five seconds and then closes again. Each successful match is reported over serial as `Huella valida ID:<n>` so the backend can log the event.
+Currently `arduino/EduSecMega/EduSecMega_R2.ino` is the recommended firmware and the version deployed on the demo panel. The previous `EduSecMega.ino` file is kept for reference. Both revisions now poll the RFID reader and fingerprint sensor in the background, printing `UID:` or `Huella valida ID:` messages whenever a card or fingerprint is detected.
+When a stored fingerprint is recognized the door relay opens for about five seconds and then closes again. Each successful match is reported over serial so the backend can log the event.
 
 ## Access System
 

--- a/arduino/EduSecMega/EduSecMega.ino
+++ b/arduino/EduSecMega/EduSecMega.ino
@@ -263,4 +263,28 @@ void loop() {
   else {
     Serial.println(F("comando no reconocido"));
   }
+
+  static unsigned long lastScan = 0;
+  if (rfidPresent && millis() - lastScan > 300) {
+    lastScan = millis();
+    if (rfid.PICC_IsNewCardPresent() && rfid.PICC_ReadCardSerial()) {
+      Serial.print(F("UID: "));
+      for (byte i = 0; i < rfid.uid.size; i++) {
+        if (rfid.uid.uidByte[i] < 0x10) Serial.print('0');
+        Serial.print(rfid.uid.uidByte[i], HEX);
+        if (i < rfid.uid.size - 1) Serial.print(':');
+      }
+      Serial.println();
+      rfid.PICC_HaltA();
+    }
+  }
+
+  static unsigned long lastFinger = 0;
+  if (fingerPresent && millis() - lastFinger > 500) {
+    lastFinger = millis();
+    if (verificarHuella()) {
+      Serial.print(F("Huella valida ID: "));
+      Serial.println(finger.fingerID);
+    }
+  }
 }

--- a/arduino/EduSecMega/README.md
+++ b/arduino/EduSecMega/README.md
@@ -26,7 +26,9 @@ The latest revision of this firmware is `EduSecMega_R2.ino`.
 
 The serial port runs at 9600 bps and expects newline-terminated commands
 (e.g. `abrir`, `enrolar 5`, `pir`). The sketch responds with a single line
-suitable for the `sendSerial` helper in the Node.js backend. Revision R2 also
+suitable for the `sendSerial` helper in the Node.js backend. Both revisions
+periodically scan the RFID reader and fingerprint sensor, printing `UID:` or
+`Huella valida ID:` messages when credentials are detected. Revision R2 also
 understands `demo 1` or `demo 0` to enable or disable the firmware's demo mode,
 allowing fingerprints to open the door even if they are not enrolled.
 


### PR DESCRIPTION
## Summary
- constantly poll for new RFID cards and fingerprints in `EduSecMega.ino`
- document the background polling behaviour

## Testing
- `npm exec eslint .` *(fails: `ReferenceError: module is not defined in ES module scope`)*
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_684c69628af083339c054842d1510d78