### PR TITLE
Fix door state update when sensor fails

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -715,11 +715,15 @@ const applyBtnStyle = () => {};
             try {
                 const data = await api('/comando/distancia');
                 const cm = parseNumber(data.resultado);
+                if (cm === null) {
+                    updateDoorUI(null);
+                    return;
+                }
                 const c = parseInt(currentSettings.doorClosedCm, 10);
                 const o = parseInt(currentSettings.doorOpenCm, 10);
                 let th = 10;
                 if (isFinite(c) && isFinite(o)) th = (c + o) / 2;
-                const open = cm !== null ? cm > th : false;
+                const open = cm > th;
                 updateDoorUI(open);
                 updateDoor(open ? '🔓 Abierta' : '🔒 Cerrada');
             } catch (err) {


### PR DESCRIPTION
## Summary
- handle invalid distance reading as unknown

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint public/panel.js` *(fails: config issue)*

------
https://chatgpt.com/codex/tasks/task_e_684c7416c1dc83339ae93b6d03ece34b