### PR TITLE
Update simulated mode label and docs

### DIFF
--- a/PanelDomoticoWeb/public/panel.js
+++ b/PanelDomoticoWeb/public/panel.js
@@ -439,7 +439,7 @@ document.addEventListener("DOMContentLoaded", () => {
                       <label for="backupFreq" class="flex-1">Frecuencia Auto-Backup (días):</label>
                       <input id="backupFreq" type="number" class="input-field w-24" />
                     </div>
-                    <label class="flex items-center gap-2"><input type="checkbox" id="chkSimMode" class="focus-ring-primary">Modo</label>
+                    <label class="flex items-center gap-2"><input type="checkbox" id="chkSimMode" class="focus-ring-primary">Modo Simulado</label>
                     <label class="flex items-center gap-2"><input type="checkbox" id="chkDemoSens" class="focus-ring-primary">Modo Demo Sensores</label>
                   </fieldset>
                   <button id="savePrefsBtn" class="btn mt-2 flex items-center gap-1"><i data-feather="save"></i>Guardar Preferencias</button>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The UI includes:
 - Silent buzzer status checks (the buzzer only sounds on alarms or when
   using the "Probar" testing button)
 - Temperature chart with hover tooltips
+- "Modo Simulado" option for configuring the system without hardware
 
 
 All components aim to be mobile friendly and accessible.
@@ -63,7 +64,12 @@ The `huella` command triggers a fingerprint check on the Arduino. If a valid fin
 
 ### Sensor Demo Mode
 
+
 Enable **Modo Demo Sensores** from the configuration screen to bypass stored credentials. When active, any RFID card read or fingerprint detected is treated as valid, allowing quick demonstrations even if enrollment fails.
+
+### Simulated Mode
+
+Enable **Modo Simulado** to gain full configuration capabilities without connecting real hardware. This mode lets you explore all settings and data management features entirely in the browser.
 
 ### Door Sensor Calibration
 


### PR DESCRIPTION
## Summary
- rename the `chkSimMode` label to "Modo Simulado"
- document the simulated mode in README
- mention the new option in the Design Overview list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c76374a8c8333b42f20518ae3d97b